### PR TITLE
feat(playback): implement playback engine state machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,14 +139,18 @@ git checkout -b feature/<ISSUE_NUMBER>-description
 
 The branch name should include the issue number when practical (e.g., `feature/42-credential-management`).
 
-### 3. Close Issues When PR is Merged
+### 3. Verify and Close Issues When PR is Merged
 
-**When a PR is closed/merged, ALL associated issues MUST be moved to Closed state.**
+**When a PR is closed/merged, ALL associated issues MUST be verified and moved to Closed state.**
 
 After PR merge:
-1. **Identify all linked issues** - Check PR description for `Closes #XXX` or related issues
-2. **Close each issue** - `gh issue close <number>` (or let GitHub auto-close via keywords)
-3. **Verify closure** - Confirm issues show as closed
+1. **Read the issue's acceptance criteria** - `gh issue view <number>`
+2. **Verify each criterion against the codebase** - Run code, grep, or test to confirm implementation
+3. **Check off each verified criterion** - Update the issue body with `[x]` for each passing item
+4. **Close each issue** - `gh issue close <number>` (or let GitHub auto-close via `Closes #XXX`)
+5. **Verify closure** - Confirm issues show as closed
+
+**Unchecked acceptance criteria on a closed issue is a red flag.** If a criterion cannot be verified, the issue is NOT done — reopen it or create a follow-up.
 
 **This rule applies even if GitHub's auto-close feature is not working as expected.**
 
@@ -248,7 +252,7 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 
 ## Session Onboarding
 
-When starting a session, read `Docs/implementation-plan.md` for current state and context.
+When starting a session, read `Docs/PRD.md` for product context and the phased implementation plan.
 
 ---
 

--- a/Docs/plan.md
+++ b/Docs/plan.md
@@ -1,0 +1,118 @@
+# Session State — Clawback
+
+## Working Directory
+`/home/bakerb/sandbox/github/clawback`
+
+## Current Branch
+`main` at `bakeb7j0/clawback` (GitHub)
+
+## Commits (pushed)
+1. `6266b78` Initial commit
+2. `b740125` feat(scaffold): set up project structure, Flask app, and build tooling
+3. `4777480` Merge PR #14 (issue #1 scaffolding)
+4. `cb20aec` feat(parser): implement client-side JSONL-to-beats parser
+5. `74a7bd0` chore(ci): add GitHub Actions CI pipeline
+6. `c222100` Merge PR #15 (issue #2 parser + CI)
+
+## PRs
+- PR #14 — merged (Issue #1: scaffolding) — AC verified and checked off
+- PR #15 — merged (Issue #2: parser + CI) — AC verified and checked off
+- No open PRs
+
+## Uncommitted Changes
+- `CLAUDE.md` modified — added SOP for AC verification on merge, updated session onboarding to point to `Docs/PRD.md`. Needs to be committed with Issue #3 work.
+
+## What Was Built
+
+### Flask Backend (`app/`)
+- `app/__init__.py` — App factory `create_app()`
+- `app/config.py` — Reads `CLAWBACK_SECRET`, `PORT`, `FLASK_DEBUG` from env
+- `app/routes/health.py` — `/health` → `{"status": "ok"}`
+- `app/routes/api.py` — `/api/sessions` → placeholder `{"sessions": []}`
+- `app/routes/views.py` — `/` → serves `index.html`
+- `app/middleware/__init__.py` — empty, auth middleware is Issue #11
+- `app/services/__init__.py` — empty, session parser service is Issue #8
+
+### Frontend (`app/static/`)
+- `index.html` — SPA shell, loads marked.js@15.0.7, highlight.js@11.11.1, parser.js, app.js, Alpine.js@3.14.9 (all `defer`, Alpine last)
+- `css/style.css` — CSS custom properties for theming, dark color scheme, header + main layout
+- `js/parser.js` — **Complete client-side JSONL-to-beats parser**. Pipeline: parseJsonlLines → filterConversationMessages → orderMessages → extractBeats → calculateDurations → assignGroupIds. Exports via `window.ClawbackParser` and `module.exports`.
+- `js/app.js` — Minimal Alpine.js `clawbackApp()` state (sessionName, view)
+
+### Tests
+- `tests/unit/conftest.py` — Flask test client fixture
+- `tests/unit/test_health.py` — 2 tests (status, content type)
+- `tests/unit/test_api.py` — 1 test (sessions endpoint)
+- `tests/unit/test_views.py` — 4 tests (HTML served, scripts present, load order, CDN pinned)
+- `tests/unit/js/test_parser.js` — 34 tests covering all parser functions
+- `tests/unit/js/fixtures/test-session.jsonl` — Synthetic fixture with all beat types
+- **Total: 41 tests (34 JS + 7 Python), all passing**
+
+### CI/CD
+- `.github/workflows/ci.yml` — 4 parallel jobs: lint, test-js, test-python, docker-build+smoke
+
+### Build/Deploy
+- `Dockerfile` — python:3.12-slim, non-root user, gunicorn, healthcheck
+- `docker-compose.yml` — optional `CLAWBACK_SECRET`, health check
+- `Makefile` — lint, format, test, test-js, test-integration, run, build, up, clean
+- `pyproject.toml` — ruff + pytest config
+- `requirements.txt` — flask, gunicorn
+- `requirements-dev.txt` — + pytest, ruff, playwright
+
+### Documentation
+- `Docs/PRD.md` — Full PRD with 7 sections, 30+ EARS requirements, 4-phase implementation plan
+- `sessions/curated/.gitkeep` — placeholder for curated sessions
+
+## Key Design Decisions
+1. **Client-side parsing for uploads** — User JSONL never leaves the browser. Privacy win. Server only serves curated sessions.
+2. **Beat model** — Each JSONL entry = one beat. No multi-block splitting needed (verified: Claude Code JSONL always has one content block per assistant message).
+3. **"Inner workings"** — Term for thinking/tool_call/tool_result. Collapsible cards with global toggle (default: collapsed).
+4. **Alpine.js must load last** — `defer` scripts execute in document order. Alpine needs `clawbackApp()` defined first. This was a bug caught by code review.
+5. **CDN versions pinned** — No floating `@3.x.x`. Exact versions: Alpine 3.14.9, marked 15.0.7, highlight.js 11.11.1.
+6. **1 issue = 1 PR** — Strict mapping, `Closes #N` in every PR.
+7. **AC verification on merge** — SOP added to CLAUDE.md: verify each criterion against codebase, check boxes on the issue, before closing.
+8. **No mocks in tests** — All tests hit real code. Flask test client for Python, real parser execution for JS.
+
+## Validation Results
+- `make lint` — passes (ruff check, zero warnings)
+- `make test` — 41/41 pass (34 JS + 7 Python)
+- Docker build — succeeds, container serves `/health` correctly
+- CI pipeline — green on PR #15
+- Parser tested against real sessions: 304 beats (this session), 3,146 beats (large session, 98ms)
+
+## PENDING
+
+### Immediate Next: Issue #3 — Playback Engine State Machine
+- Branch: `feature/3-playback-engine` (not yet created)
+- File: `app/static/js/playback.js`
+- States: READY → PLAYING → PAUSED / SCROLL_PAUSED → COMPLETE
+- Must implement: play(), pause(), scrollPause(), next(), previous(), skipToStart(), skipToEnd(), setSpeed(), setInnerWorkingsMode()
+- Callbacks: onBeat(beat), onStateChange(state)
+- Inner workings collapsed mode skips beat durations
+- **Also commit the CLAUDE.md changes (AC verification SOP) as part of this work**
+
+### Remaining Issues (11 open)
+- **Phase 1:** #3 (playback engine) — NEXT
+- **Phase 2:** #4 (chat bubbles), #5 (inner working cards), #6 (auto-scroll)
+- **Phase 3:** #7 (toolbar), #8 (session picker + upload), #9 (visual polish), #10 (Playwright tests)
+- **Phase 4:** #11 (auth middleware), #12 (curated sessions), #13 (Docker + docs)
+
+### Dependency chain
+- #3 is independent (only needs parser from #2, which is merged)
+- #4 needs #3 (renderer wires to playback engine onBeat callback)
+- #5 needs #4
+- #6 needs #3 + #4
+- #7 needs #3 + #4 + #5
+- #8 needs #2 + #3 + #4
+- #9 depends on #7 + #8
+- #10 depends on all of Phase 2 + 3
+- #11 is independent (just Flask middleware)
+- #12 needs #8
+- #13 needs #11 + #12
+
+## Lessons Learned
+- **Alpine.js `defer` race** — If Alpine loads before app.js, `clawbackApp()` is undefined. Always declare Alpine's script tag LAST among defer scripts.
+- **Floating CDN versions** — `@3.x.x` resolves to latest at request time. Pin exact versions always.
+- **JSONL structure** — Claude Code writes one content block per assistant JSONL entry (never multi-block). Simplifies parser significantly.
+- **AC checkbox discipline** — Issue #1 was merged with all boxes unchecked. Now an explicit SOP in CLAUDE.md.
+- **Code review catches wiring bugs** — Unit tests passed but the parser wasn't even loaded in the HTML. Always run the code review agent before merge.

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ test: test-js
 
 test-js:
 	node tests/unit/js/test_parser.js
+	node tests/unit/js/test_playback.js
 
 test-integration:
 	python -m pytest tests/integration/ -v

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -11,6 +11,7 @@
     <script defer src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js"></script>
     <!-- Clawback modules -->
     <script defer src="/static/js/parser.js"></script>
+    <script defer src="/static/js/playback.js"></script>
     <script defer src="/static/js/app.js"></script>
     <!-- Alpine.js MUST be last — defer scripts execute in order, and Alpine
          needs clawbackApp() to be defined before it initializes -->

--- a/app/static/js/playback.js
+++ b/app/static/js/playback.js
@@ -1,0 +1,298 @@
+/**
+ * Clawback — Playback engine state machine.
+ *
+ * Manages timed beat-by-beat playback with transport controls,
+ * speed adjustment, and inner workings mode support.
+ *
+ * Timing model (show-then-wait):
+ *   1. Beat is rendered immediately (onBeat fires)
+ *   2. Engine waits for the beat's reading duration
+ *   3. Next beat renders, repeat
+ */
+
+const PlaybackState = Object.freeze({
+    READY: "READY",
+    PLAYING: "PLAYING",
+    PAUSED: "PAUSED",
+    SCROLL_PAUSED: "SCROLL_PAUSED",
+    COMPLETE: "COMPLETE",
+});
+
+class PlaybackEngine {
+    /**
+     * @param {Object} options
+     * @param {Array<Object>} options.beats - Beat array from the parser
+     * @param {Function} [options.onBeat] - Called when a beat is rendered: onBeat(beat)
+     * @param {Function} [options.onRemoveBeat] - Called when a beat is removed: onRemoveBeat(beat)
+     * @param {Function} [options.onStateChange] - Called on state transitions: onStateChange(newState, oldState)
+     */
+    constructor({ beats = [], onBeat = null, onRemoveBeat = null, onStateChange = null } = {}) {
+        this.beats = beats;
+        this.onBeat = onBeat;
+        this.onRemoveBeat = onRemoveBeat;
+        this.onStateChange = onStateChange;
+
+        this.state = PlaybackState.READY;
+        this.currentIndex = 0;
+        this.speed = 1.0;
+        this.innerWorkingsMode = "expanded";
+
+        this._timer = null;
+        this._beatStartTime = null;
+        this._remainingFraction = null;
+        this._lastRenderedIndex = null;
+    }
+
+    /** Start or resume timed beat rendering. */
+    play() {
+        if (this.state === PlaybackState.COMPLETE) return;
+        if (this.state === PlaybackState.PLAYING) return;
+        if (this.beats.length === 0) return;
+
+        if (this.currentIndex >= this.beats.length) {
+            this._setState(PlaybackState.COMPLETE);
+            return;
+        }
+
+        const wasPaused =
+            this.state === PlaybackState.PAUSED ||
+            this.state === PlaybackState.SCROLL_PAUSED;
+
+        this._setState(PlaybackState.PLAYING);
+
+        if (wasPaused && this._remainingFraction !== null && this._lastRenderedIndex !== null) {
+            this._scheduleWait(this._lastRenderedIndex, this._remainingFraction);
+        } else {
+            this._advanceAndSchedule();
+        }
+    }
+
+    /** Pause beat rendering. */
+    pause() {
+        if (this.state !== PlaybackState.PLAYING) return;
+        this._pauseInternal(PlaybackState.PAUSED);
+    }
+
+    /** Pause due to user scrolling back. Resumable with play(). */
+    scrollPause() {
+        if (this.state !== PlaybackState.PLAYING) return;
+        this._pauseInternal(PlaybackState.SCROLL_PAUSED);
+    }
+
+    /** Immediately advance to the next beat. */
+    next() {
+        if (this.currentIndex >= this.beats.length) return;
+        if (this.state === PlaybackState.COMPLETE) return;
+
+        this._clearTimer();
+        this._remainingFraction = null;
+
+        const beatIndex = this.currentIndex;
+        this._renderCurrentBeat();
+
+        if (this.currentIndex >= this.beats.length) {
+            this._setState(PlaybackState.COMPLETE);
+        } else if (this.state === PlaybackState.PLAYING) {
+            this._scheduleWait(beatIndex, 1.0);
+        }
+    }
+
+    /** Remove the last rendered beat. */
+    previous() {
+        if (this.currentIndex <= 0) return;
+
+        const wasPlaying = this.state === PlaybackState.PLAYING;
+
+        this._clearTimer();
+        this._remainingFraction = null;
+        this.currentIndex--;
+
+        const beat = this.beats[this.currentIndex];
+        if (this.onRemoveBeat) {
+            this.onRemoveBeat(beat);
+        }
+
+        if (
+            this.state === PlaybackState.COMPLETE ||
+            wasPlaying ||
+            this.state === PlaybackState.SCROLL_PAUSED
+        ) {
+            this._setState(PlaybackState.PAUSED);
+        }
+    }
+
+    /** Reset to the beginning, removing all rendered beats. */
+    skipToStart() {
+        this._clearTimer();
+        this._remainingFraction = null;
+
+        while (this.currentIndex > 0) {
+            this.currentIndex--;
+            if (this.onRemoveBeat) {
+                this.onRemoveBeat(this.beats[this.currentIndex]);
+            }
+        }
+
+        this._setState(PlaybackState.READY);
+    }
+
+    /** Render all remaining beats immediately. */
+    skipToEnd() {
+        this._clearTimer();
+        this._remainingFraction = null;
+
+        while (this.currentIndex < this.beats.length) {
+            this._renderCurrentBeat();
+        }
+
+        this._setState(PlaybackState.COMPLETE);
+    }
+
+    /**
+     * Set the speed multiplier. Recalculates remaining wait if playing.
+     * @param {number} multiplier - e.g. 0.5, 1.0, 1.5, 2.0
+     */
+    setSpeed(multiplier) {
+        if (multiplier <= 0) return;
+        const oldSpeed = this.speed;
+        this.speed = multiplier;
+
+        if (
+            this.state === PlaybackState.PLAYING &&
+            this._beatStartTime !== null &&
+            this._lastRenderedIndex !== null
+        ) {
+            const elapsed = Date.now() - this._beatStartTime;
+            const oldTotalMs = this._getBeatDurationMs(this.beats[this._lastRenderedIndex], oldSpeed);
+            const fraction = oldTotalMs > 0 ? Math.max(0, 1 - elapsed / oldTotalMs) : 0;
+
+            this._clearTimer();
+            this._scheduleWait(this._lastRenderedIndex, fraction);
+        }
+    }
+
+    /**
+     * Set inner workings display mode.
+     * @param {string} mode - "expanded" or "collapsed"
+     */
+    setInnerWorkingsMode(mode) {
+        this.innerWorkingsMode = mode;
+    }
+
+    // ---- Internal ----
+
+    _setState(newState) {
+        const oldState = this.state;
+        if (oldState === newState) return;
+        this.state = newState;
+        if (this.onStateChange) {
+            this.onStateChange(newState, oldState);
+        }
+    }
+
+    _renderCurrentBeat() {
+        const beat = this.beats[this.currentIndex];
+        this.currentIndex++;
+        if (this.onBeat) {
+            this.onBeat(beat);
+        }
+    }
+
+    /**
+     * Renders beats and schedules waits. Uses a loop for zero-duration beats
+     * to avoid stack overflow with many consecutive collapsed inner workings.
+     */
+    _advanceAndSchedule() {
+        while (this.state === PlaybackState.PLAYING) {
+            if (this.currentIndex >= this.beats.length) {
+                this._setState(PlaybackState.COMPLETE);
+                return;
+            }
+
+            const beatIndex = this.currentIndex;
+            this._renderCurrentBeat();
+
+            // Guard: onBeat callback may have changed state (e.g. called pause())
+            if (this.state !== PlaybackState.PLAYING) return;
+
+            if (this.currentIndex >= this.beats.length) {
+                this._setState(PlaybackState.COMPLETE);
+                return;
+            }
+
+            const durationMs = this._getBeatDurationMs(this.beats[beatIndex]);
+            if (durationMs <= 0) {
+                continue;
+            }
+
+            this._scheduleWait(beatIndex, 1.0);
+            return;
+        }
+    }
+
+    _scheduleWait(beatIndex, fraction) {
+        const beat = this.beats[beatIndex];
+        const totalMs = this._getBeatDurationMs(beat);
+        const waitMs = totalMs * fraction;
+
+        this._lastRenderedIndex = beatIndex;
+
+        if (waitMs <= 0) {
+            this._beatStartTime = null;
+            this._remainingFraction = null;
+            this._advanceAndSchedule();
+            return;
+        }
+
+        this._beatStartTime = Date.now();
+        this._remainingFraction = fraction;
+
+        this._timer = setTimeout(() => {
+            this._timer = null;
+            this._beatStartTime = null;
+            this._remainingFraction = null;
+
+            if (this.state === PlaybackState.PLAYING) {
+                this._advanceAndSchedule();
+            }
+        }, waitMs);
+    }
+
+    _getBeatDurationMs(beat, speed) {
+        speed = speed !== undefined ? speed : this.speed;
+        if (this.innerWorkingsMode === "collapsed" && beat.category === "inner_working") {
+            return 0;
+        }
+        return (beat.duration * 1000) / speed;
+    }
+
+    _pauseInternal(state) {
+        if (this._beatStartTime !== null && this._lastRenderedIndex !== null) {
+            const elapsed = Date.now() - this._beatStartTime;
+            const totalMs = this._getBeatDurationMs(this.beats[this._lastRenderedIndex]);
+            this._remainingFraction = totalMs > 0 ? Math.max(0, 1 - elapsed / totalMs) : 0;
+        }
+
+        this._clearTimer();
+        this._setState(state);
+    }
+
+    _clearTimer() {
+        if (this._timer !== null) {
+            clearTimeout(this._timer);
+            this._timer = null;
+        }
+        this._beatStartTime = null;
+    }
+}
+
+// Browser export
+if (typeof window !== "undefined") {
+    window.PlaybackState = PlaybackState;
+    window.PlaybackEngine = PlaybackEngine;
+}
+
+// CommonJS export for Node.js testing
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { PlaybackState, PlaybackEngine };
+}

--- a/tests/unit/js/test_playback.js
+++ b/tests/unit/js/test_playback.js
@@ -1,0 +1,757 @@
+/**
+ * Clawback — Unit tests for the playback engine.
+ *
+ * Run with: node tests/unit/js/test_playback.js
+ * Or via:   make test-js
+ */
+
+const assert = require("node:assert/strict");
+const { PlaybackState, PlaybackEngine } = require("../../../app/static/js/playback.js");
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        passed++;
+        console.log(`  \u2713 ${name}`);
+    } catch (err) {
+        failed++;
+        console.log(`  \u2717 ${name}`);
+        console.log(`    ${err.message}`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBeat(id, opts = {}) {
+    return {
+        id,
+        type: opts.type || "assistant_message",
+        category: opts.category || "direct",
+        content: opts.content || "test content",
+        metadata: {},
+        duration: opts.duration !== undefined ? opts.duration : 2.0,
+        group_id: opts.group_id || null,
+    };
+}
+
+function makeInnerBeat(id, opts = {}) {
+    return makeBeat(id, {
+        type: opts.type || "thinking",
+        category: "inner_working",
+        ...opts,
+    });
+}
+
+// ---------------------------------------------------------------------------
+// PlaybackState
+// ---------------------------------------------------------------------------
+console.log("\nPlaybackState");
+
+test("has all five states", () => {
+    assert.equal(PlaybackState.READY, "READY");
+    assert.equal(PlaybackState.PLAYING, "PLAYING");
+    assert.equal(PlaybackState.PAUSED, "PAUSED");
+    assert.equal(PlaybackState.SCROLL_PAUSED, "SCROLL_PAUSED");
+    assert.equal(PlaybackState.COMPLETE, "COMPLETE");
+});
+
+test("is frozen (immutable)", () => {
+    assert.ok(Object.isFrozen(PlaybackState));
+});
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+console.log("\nConstructor");
+
+test("initial state is READY", () => {
+    const engine = new PlaybackEngine({ beats: [makeBeat(0)] });
+    assert.equal(engine.state, PlaybackState.READY);
+});
+
+test("currentIndex starts at 0", () => {
+    const engine = new PlaybackEngine({ beats: [makeBeat(0)] });
+    assert.equal(engine.currentIndex, 0);
+});
+
+test("default speed is 1.0", () => {
+    const engine = new PlaybackEngine();
+    assert.equal(engine.speed, 1.0);
+});
+
+test("default innerWorkingsMode is expanded", () => {
+    const engine = new PlaybackEngine();
+    assert.equal(engine.innerWorkingsMode, "expanded");
+});
+
+test("handles construction with no arguments", () => {
+    const engine = new PlaybackEngine();
+    assert.equal(engine.state, PlaybackState.READY);
+    assert.equal(engine.beats.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// play()
+// ---------------------------------------------------------------------------
+console.log("\nplay()");
+
+test("renders first beat synchronously", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.play();
+    assert.equal(rendered.length, 1, "first beat should render immediately");
+    assert.equal(rendered[0].id, 0);
+    engine.pause();
+});
+
+test("transitions to PLAYING", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.play();
+    assert.equal(engine.state, PlaybackState.PLAYING);
+    engine.pause();
+});
+
+test("fires onStateChange with PLAYING", () => {
+    const transitions = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+        onStateChange: (newState, oldState) => transitions.push({ newState, oldState }),
+    });
+    engine.play();
+    assert.equal(transitions.length, 1);
+    assert.equal(transitions[0].newState, PlaybackState.PLAYING);
+    assert.equal(transitions[0].oldState, PlaybackState.READY);
+    engine.pause();
+});
+
+test("no-op when COMPLETE", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.skipToEnd();
+    const countAfterComplete = rendered.length;
+    engine.play();
+    assert.equal(rendered.length, countAfterComplete, "should not render more beats");
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+});
+
+test("no-op when already PLAYING", () => {
+    const transitions = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+        onStateChange: (newState) => transitions.push(newState),
+    });
+    engine.play();
+    const countAfterFirst = transitions.length;
+    engine.play(); // should be no-op
+    assert.equal(transitions.length, countAfterFirst);
+    engine.pause();
+});
+
+test("no-op with empty beats", () => {
+    const transitions = [];
+    const engine = new PlaybackEngine({
+        beats: [],
+        onStateChange: () => transitions.push(true),
+    });
+    engine.play();
+    assert.equal(transitions.length, 0);
+    assert.equal(engine.state, PlaybackState.READY);
+});
+
+test("transitions to COMPLETE if only one beat", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.play();
+    assert.equal(rendered.length, 1);
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+});
+
+// ---------------------------------------------------------------------------
+// pause()
+// ---------------------------------------------------------------------------
+console.log("\npause()");
+
+test("transitions from PLAYING to PAUSED", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.play();
+    engine.pause();
+    assert.equal(engine.state, PlaybackState.PAUSED);
+});
+
+test("no-op when not PLAYING", () => {
+    const transitions = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0)],
+        onStateChange: () => transitions.push(true),
+    });
+    engine.pause();
+    assert.equal(transitions.length, 0);
+    assert.equal(engine.state, PlaybackState.READY);
+});
+
+// ---------------------------------------------------------------------------
+// scrollPause()
+// ---------------------------------------------------------------------------
+console.log("\nscrollPause()");
+
+test("transitions from PLAYING to SCROLL_PAUSED", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.play();
+    engine.scrollPause();
+    assert.equal(engine.state, PlaybackState.SCROLL_PAUSED);
+});
+
+test("no-op when not PLAYING", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0)],
+    });
+    engine.scrollPause();
+    assert.equal(engine.state, PlaybackState.READY);
+});
+
+// ---------------------------------------------------------------------------
+// play() from paused states
+// ---------------------------------------------------------------------------
+console.log("\nplay() resume");
+
+test("resumes from PAUSED to PLAYING", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+    });
+    engine.play();
+    engine.pause();
+    assert.equal(engine.state, PlaybackState.PAUSED);
+    engine.play();
+    assert.equal(engine.state, PlaybackState.PLAYING);
+    engine.pause();
+});
+
+test("resumes from SCROLL_PAUSED to PLAYING", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+    });
+    engine.play();
+    engine.scrollPause();
+    assert.equal(engine.state, PlaybackState.SCROLL_PAUSED);
+    engine.play();
+    assert.equal(engine.state, PlaybackState.PLAYING);
+    engine.pause();
+});
+
+// ---------------------------------------------------------------------------
+// next()
+// ---------------------------------------------------------------------------
+console.log("\nnext()");
+
+test("renders one beat and fires onBeat", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.next();
+    assert.equal(rendered.length, 1);
+    assert.equal(rendered[0].id, 0);
+    assert.equal(engine.currentIndex, 1);
+});
+
+test("transitions to COMPLETE at last beat", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0)],
+    });
+    engine.next();
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+});
+
+test("no-op when COMPLETE", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.skipToEnd();
+    const count = rendered.length;
+    engine.next();
+    assert.equal(rendered.length, count);
+});
+
+test("works from READY state without changing state", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.next();
+    assert.equal(engine.state, PlaybackState.READY);
+    assert.equal(engine.currentIndex, 1);
+});
+
+test("works from PAUSED state without changing state", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+    });
+    engine.play();
+    engine.pause();
+    engine.next();
+    assert.equal(engine.state, PlaybackState.PAUSED);
+});
+
+test("during PLAYING reschedules after rendering", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.play(); // renders beat 0
+    assert.equal(rendered.length, 1);
+    engine.next(); // renders beat 1, reschedules
+    assert.equal(rendered.length, 2);
+    assert.equal(rendered[1].id, 1);
+    assert.equal(engine.state, PlaybackState.PLAYING);
+    engine.pause();
+});
+
+// ---------------------------------------------------------------------------
+// previous()
+// ---------------------------------------------------------------------------
+console.log("\nprevious()");
+
+test("fires onRemoveBeat callback", () => {
+    const removed = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+        onRemoveBeat: (beat) => removed.push(beat),
+    });
+    engine.next();
+    engine.next();
+    engine.previous();
+    assert.equal(removed.length, 1);
+    assert.equal(removed[0].id, 1);
+});
+
+test("decrements currentIndex", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.next();
+    engine.next();
+    assert.equal(engine.currentIndex, 2);
+    engine.previous();
+    assert.equal(engine.currentIndex, 1);
+});
+
+test("transitions COMPLETE to PAUSED", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0)],
+    });
+    engine.skipToEnd();
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+    engine.previous();
+    assert.equal(engine.state, PlaybackState.PAUSED);
+});
+
+test("transitions PLAYING to PAUSED", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+    });
+    engine.play();
+    engine.previous();
+    assert.equal(engine.state, PlaybackState.PAUSED);
+});
+
+test("no-op at start", () => {
+    const removed = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0)],
+        onRemoveBeat: (beat) => removed.push(beat),
+    });
+    engine.previous();
+    assert.equal(removed.length, 0);
+    assert.equal(engine.currentIndex, 0);
+});
+
+test("transitions SCROLL_PAUSED to PAUSED", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+    });
+    engine.play();
+    engine.scrollPause();
+    assert.equal(engine.state, PlaybackState.SCROLL_PAUSED);
+    engine.previous();
+    assert.equal(engine.state, PlaybackState.PAUSED);
+    assert.equal(engine.currentIndex, 0);
+});
+
+// ---------------------------------------------------------------------------
+// skipToStart()
+// ---------------------------------------------------------------------------
+console.log("\nskipToStart()");
+
+test("removes all rendered beats in reverse order", () => {
+    const removed = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+        onRemoveBeat: (beat) => removed.push(beat),
+    });
+    engine.skipToEnd();
+    engine.skipToStart();
+    assert.equal(removed.length, 3);
+    assert.deepEqual(
+        removed.map((b) => b.id),
+        [2, 1, 0],
+        "should remove in reverse order",
+    );
+});
+
+test("transitions to READY", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0)],
+    });
+    engine.skipToEnd();
+    engine.skipToStart();
+    assert.equal(engine.state, PlaybackState.READY);
+});
+
+test("resets currentIndex to 0", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.skipToEnd();
+    engine.skipToStart();
+    assert.equal(engine.currentIndex, 0);
+});
+
+// ---------------------------------------------------------------------------
+// skipToEnd()
+// ---------------------------------------------------------------------------
+console.log("\nskipToEnd()");
+
+test("renders all remaining beats", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.skipToEnd();
+    assert.equal(rendered.length, 3);
+});
+
+test("transitions to COMPLETE", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.skipToEnd();
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+});
+
+test("fires onBeat for each beat in order", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.skipToEnd();
+    assert.deepEqual(
+        rendered.map((b) => b.id),
+        [0, 1, 2],
+    );
+});
+
+test("only renders unrendered beats", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.next(); // render beat 0
+    engine.skipToEnd(); // render beats 1, 2
+    assert.equal(rendered.length, 3);
+    assert.deepEqual(
+        rendered.map((b) => b.id),
+        [0, 1, 2],
+    );
+});
+
+// ---------------------------------------------------------------------------
+// setSpeed()
+// ---------------------------------------------------------------------------
+console.log("\nsetSpeed()");
+
+test("updates speed multiplier", () => {
+    const engine = new PlaybackEngine();
+    engine.setSpeed(2.0);
+    assert.equal(engine.speed, 2.0);
+});
+
+test("rejects zero", () => {
+    const engine = new PlaybackEngine();
+    engine.setSpeed(0);
+    assert.equal(engine.speed, 1.0, "should remain at default");
+});
+
+test("rejects negative", () => {
+    const engine = new PlaybackEngine();
+    engine.setSpeed(-1);
+    assert.equal(engine.speed, 1.0, "should remain at default");
+});
+
+test("rescheduling during playback preserves timer state", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0, { duration: 10.0 }), makeBeat(1)],
+    });
+    engine.play(); // renders beat 0, schedules 10s wait
+    assert.ok(engine._timer !== null, "timer should be active");
+    assert.ok(engine._beatStartTime !== null, "beat start time should be set");
+
+    engine.setSpeed(2.0);
+    // Timer should be rescheduled
+    assert.ok(engine._timer !== null, "timer should still be active after speed change");
+    assert.equal(engine.speed, 2.0);
+    engine.pause();
+});
+
+test("affects beat duration calculation", () => {
+    const beat = makeBeat(0, { duration: 4.0 });
+    const engine = new PlaybackEngine({ beats: [beat] });
+
+    // At 1x: 4.0 * 1000 / 1.0 = 4000ms
+    assert.equal(engine._getBeatDurationMs(beat), 4000);
+
+    engine.setSpeed(2.0);
+    // At 2x: 4.0 * 1000 / 2.0 = 2000ms
+    assert.equal(engine._getBeatDurationMs(beat), 2000);
+
+    engine.setSpeed(0.5);
+    // At 0.5x: 4.0 * 1000 / 0.5 = 8000ms
+    assert.equal(engine._getBeatDurationMs(beat), 8000);
+});
+
+// ---------------------------------------------------------------------------
+// setInnerWorkingsMode()
+// ---------------------------------------------------------------------------
+console.log("\nsetInnerWorkingsMode()");
+
+test("stores mode", () => {
+    const engine = new PlaybackEngine();
+    engine.setInnerWorkingsMode("collapsed");
+    assert.equal(engine.innerWorkingsMode, "collapsed");
+    engine.setInnerWorkingsMode("expanded");
+    assert.equal(engine.innerWorkingsMode, "expanded");
+});
+
+test("collapsed mode gives zero duration for inner_working beats", () => {
+    const inner = makeInnerBeat(0, { duration: 5.0 });
+    const direct = makeBeat(1, { duration: 5.0 });
+    const engine = new PlaybackEngine({ beats: [inner, direct] });
+
+    engine.setInnerWorkingsMode("collapsed");
+    assert.equal(engine._getBeatDurationMs(inner), 0, "inner_working should be 0");
+    assert.equal(engine._getBeatDurationMs(direct), 5000, "direct should be unaffected");
+});
+
+test("expanded mode preserves duration for inner_working beats", () => {
+    const inner = makeInnerBeat(0, { duration: 5.0 });
+    const engine = new PlaybackEngine({ beats: [inner] });
+
+    engine.setInnerWorkingsMode("expanded");
+    assert.equal(engine._getBeatDurationMs(inner), 5000);
+});
+
+// ---------------------------------------------------------------------------
+// Inner workings collapsed playback
+// ---------------------------------------------------------------------------
+console.log("\nInner workings collapsed playback");
+
+test("zero-duration inner_working beats advance synchronously during play", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [
+            makeInnerBeat(0, { type: "thinking" }),
+            makeInnerBeat(1, { type: "tool_call" }),
+            makeBeat(2, { type: "assistant_message" }),
+            makeBeat(3, { type: "user_message" }),
+        ],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.setInnerWorkingsMode("collapsed");
+    engine.play();
+
+    // Beats 0,1 have zero duration (collapsed), beat 2 is direct with non-zero duration
+    // All three render synchronously, then timer schedules for beat 2's reading time
+    assert.equal(rendered.length, 3, "should render 3 beats synchronously");
+    assert.equal(engine.state, PlaybackState.PLAYING);
+    engine.pause();
+});
+
+test("all zero-duration beats transition to COMPLETE synchronously", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [
+            makeInnerBeat(0, { type: "thinking" }),
+            makeInnerBeat(1, { type: "tool_call" }),
+        ],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.setInnerWorkingsMode("collapsed");
+    engine.play();
+
+    assert.equal(rendered.length, 2);
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+});
+
+// ---------------------------------------------------------------------------
+// onStateChange
+// ---------------------------------------------------------------------------
+console.log("\nonStateChange");
+
+test("receives newState and oldState", () => {
+    const transitions = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+        onStateChange: (newState, oldState) => transitions.push({ newState, oldState }),
+    });
+    engine.play();
+    engine.pause();
+
+    assert.equal(transitions[0].newState, PlaybackState.PLAYING);
+    assert.equal(transitions[0].oldState, PlaybackState.READY);
+    assert.equal(transitions[1].newState, PlaybackState.PAUSED);
+    assert.equal(transitions[1].oldState, PlaybackState.PLAYING);
+});
+
+test("does not fire for redundant transitions", () => {
+    const transitions = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0)],
+        onStateChange: () => transitions.push(true),
+    });
+    // READY → READY should not fire
+    engine.pause(); // no-op, stays READY
+    assert.equal(transitions.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Integration
+// ---------------------------------------------------------------------------
+console.log("\nIntegration");
+
+test("play → next → next → complete cycle", () => {
+    const rendered = [];
+    const transitions = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+        onBeat: (beat) => rendered.push(beat),
+        onStateChange: (newState) => transitions.push(newState),
+    });
+
+    engine.play();   // renders beat 0, READY→PLAYING
+    engine.next();   // renders beat 1
+    engine.next();   // renders beat 2, PLAYING→COMPLETE
+
+    assert.equal(rendered.length, 3);
+    assert.deepEqual(rendered.map((b) => b.id), [0, 1, 2]);
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+});
+
+test("skipToEnd → skipToStart → play replays from beginning", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+
+    engine.skipToEnd();
+    assert.equal(rendered.length, 2);
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+
+    engine.skipToStart();
+    assert.equal(engine.currentIndex, 0);
+    assert.equal(engine.state, PlaybackState.READY);
+
+    engine.play();
+    // First beat renders synchronously again
+    assert.equal(rendered.length, 3, "should render beat 0 again");
+    assert.equal(rendered[2].id, 0);
+    engine.pause();
+});
+
+test("next → previous → next cycle", () => {
+    const rendered = [];
+    const removed = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+        onBeat: (beat) => rendered.push(beat),
+        onRemoveBeat: (beat) => removed.push(beat),
+    });
+
+    engine.next();   // renders beat 0
+    engine.next();   // renders beat 1
+    engine.previous(); // removes beat 1
+    engine.next();   // renders beat 1 again
+
+    assert.equal(rendered.length, 3);
+    assert.deepEqual(rendered.map((b) => b.id), [0, 1, 1]);
+    assert.equal(removed.length, 1);
+    assert.equal(removed[0].id, 1);
+});
+
+test("onBeat callback calling pause stops playback cleanly", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+        onBeat: (beat) => {
+            rendered.push(beat);
+            if (beat.id === 0) {
+                engine.pause();
+            }
+        },
+    });
+    engine.play();
+    // onBeat fires for beat 0, which calls pause()
+    // Engine should stop — no phantom timer, no further beats rendered
+    assert.equal(rendered.length, 1);
+    assert.equal(engine.state, PlaybackState.PAUSED);
+    assert.equal(engine._timer, null, "no timer should be scheduled after pause");
+});
+
+test("previous from PLAYING pauses and allows replay", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+
+    engine.play();     // renders beat 0
+    engine.previous(); // removes beat 0, PLAYING→PAUSED
+    assert.equal(engine.state, PlaybackState.PAUSED);
+    assert.equal(engine.currentIndex, 0);
+
+    engine.play(); // renders beat 0 again
+    assert.equal(engine.state, PlaybackState.PLAYING);
+    assert.equal(rendered.length, 2);
+    engine.pause();
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -12,6 +12,7 @@ def test_index_loads_all_required_scripts(client):
     """Index page includes all required script tags."""
     html = client.get("/").data.decode()
     assert "parser.js" in html, "parser.js must be loaded"
+    assert "playback.js" in html, "playback.js must be loaded"
     assert "app.js" in html, "app.js must be loaded"
     assert "alpinejs" in html, "Alpine.js must be loaded"
     assert "marked" in html, "marked.js must be loaded"
@@ -29,6 +30,8 @@ def test_index_script_load_order(client):
     def lib_name(src):
         if "parser.js" in src:
             return "parser"
+        if "playback.js" in src:
+            return "playback"
         if "app.js" in src:
             return "app"
         if "alpinejs" in src:
@@ -41,7 +44,8 @@ def test_index_script_load_order(client):
 
     order = [lib_name(s) for s in script_tags]
 
-    assert order.index("parser") < order.index("app"), "parser.js must load before app.js"
+    assert order.index("parser") < order.index("playback"), "parser.js must load before playback.js"
+    assert order.index("playback") < order.index("app"), "playback.js must load before app.js"
     assert order.index("app") < order.index("alpine"), "app.js must load before Alpine.js"
 
 


### PR DESCRIPTION
## Summary
- Implements `PlaybackEngine` class with 5-state machine (READY → PLAYING → PAUSED / SCROLL_PAUSED → COMPLETE)
- Transport controls: `play()`, `pause()`, `scrollPause()`, `next()`, `previous()`, `skipToStart()`, `skipToEnd()`
- Speed multiplier with mid-playback recalculation, inner workings collapsed mode (zero-duration skip)
- `onBeat`, `onRemoveBeat`, `onStateChange` callbacks; show-then-wait timing model
- 56 unit tests covering all state transitions, edge cases, re-entrancy safety (onBeat calling pause)
- Wired `playback.js` into `index.html` (parser → playback → app → Alpine load order)
- Also rolls in CLAUDE.md AC verification SOP and session state doc from prior work

## Test plan
- [x] `node tests/unit/js/test_playback.js` — 56/56 pass
- [x] `node tests/unit/js/test_parser.js` — 34/34 pass
- [x] `pytest tests/unit/ -v` — 7/7 pass (including new playback.js load order assertions)
- [x] `make lint` — clean
- [x] CI pipeline passes

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)