### PR TITLE
feat(renderer): implement chat bubble rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ test: test-js
 test-js:
 	node tests/unit/js/test_parser.js
 	node tests/unit/js/test_playback.js
+	node tests/unit/js/test_renderer.js
 
 test-integration:
 	python -m pytest tests/integration/ -v

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -72,3 +72,177 @@ body {
     color: var(--color-text-muted);
     font-size: 1.125rem;
 }
+
+/* -----------------------------------------------------------------------
+   Chat area
+   ----------------------------------------------------------------------- */
+.chat-area {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 24px 0;
+}
+
+/* -----------------------------------------------------------------------
+   Bubbles — base
+   ----------------------------------------------------------------------- */
+.bubble {
+    position: relative;
+    padding: 12px 16px;
+    border-radius: 12px;
+    max-width: 80%;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    animation: fadeSlideUp 0.3s ease-out;
+    line-height: 1.6;
+}
+
+/* User bubble — right-aligned, distinct background */
+.bubble--user {
+    align-self: flex-end;
+    background-color: var(--color-user-bubble);
+    border-bottom-right-radius: 4px;
+}
+
+/* Assistant bubble — left-aligned, bordered */
+.bubble--assistant {
+    align-self: flex-start;
+    background-color: var(--color-assistant-bubble);
+    border: 1px solid var(--color-border);
+    border-bottom-left-radius: 4px;
+}
+
+/* Beat number metadata — hidden by default, shown via container class */
+.bubble__meta {
+    display: none;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    margin-top: 4px;
+    text-align: right;
+}
+
+.chat-area--show-meta .bubble__meta {
+    display: block;
+}
+
+/* Bubble appear animation */
+@keyframes fadeSlideUp {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* -----------------------------------------------------------------------
+   Markdown content within assistant bubbles
+   ----------------------------------------------------------------------- */
+.bubble--assistant h1,
+.bubble--assistant h2,
+.bubble--assistant h3,
+.bubble--assistant h4,
+.bubble--assistant h5,
+.bubble--assistant h6 {
+    margin-top: 0.5em;
+    margin-bottom: 0.25em;
+    line-height: 1.3;
+}
+
+.bubble--assistant h1:first-child,
+.bubble--assistant h2:first-child,
+.bubble--assistant h3:first-child {
+    margin-top: 0;
+}
+
+.bubble--assistant h1 { font-size: 1.4em; }
+.bubble--assistant h2 { font-size: 1.2em; }
+.bubble--assistant h3 { font-size: 1.1em; }
+
+.bubble--assistant p {
+    margin-bottom: 0.5em;
+}
+
+.bubble--assistant p:last-child {
+    margin-bottom: 0;
+}
+
+.bubble--assistant ul,
+.bubble--assistant ol {
+    margin: 0.5em 0;
+    padding-left: 1.5em;
+}
+
+.bubble--assistant li {
+    margin-bottom: 0.25em;
+}
+
+.bubble--assistant code {
+    font-family: var(--font-mono);
+    background-color: rgba(0, 0, 0, 0.3);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+
+.bubble--assistant pre {
+    margin: 0.5em 0;
+    border-radius: 6px;
+    overflow-x: auto;
+}
+
+.bubble--assistant pre code {
+    display: block;
+    padding: 12px;
+    background-color: rgba(0, 0, 0, 0.3);
+    font-size: 0.85em;
+    line-height: 1.5;
+}
+
+.bubble--assistant table {
+    border-collapse: collapse;
+    margin: 0.5em 0;
+    width: 100%;
+}
+
+.bubble--assistant th,
+.bubble--assistant td {
+    border: 1px solid var(--color-border);
+    padding: 6px 12px;
+    text-align: left;
+}
+
+.bubble--assistant th {
+    background-color: rgba(0, 0, 0, 0.2);
+}
+
+.bubble--assistant blockquote {
+    border-left: 3px solid var(--color-accent);
+    padding-left: 12px;
+    margin: 0.5em 0;
+    color: var(--color-text-muted);
+}
+
+.bubble--assistant a {
+    color: var(--color-accent);
+    text-decoration: none;
+}
+
+.bubble--assistant a:hover {
+    color: var(--color-accent-hover);
+    text-decoration: underline;
+}
+
+.bubble--assistant strong {
+    font-weight: 600;
+}
+
+.bubble--assistant hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: 0.75em 0;
+}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -9,9 +9,11 @@
     <script defer src="https://cdn.jsdelivr.net/npm/marked@15.0.7/marked.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github-dark.min.css">
     <script defer src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/dompurify@3.2.3/dist/purify.min.js"></script>
     <!-- Clawback modules -->
     <script defer src="/static/js/parser.js"></script>
     <script defer src="/static/js/playback.js"></script>
+    <script defer src="/static/js/renderer.js"></script>
     <script defer src="/static/js/app.js"></script>
     <!-- Alpine.js MUST be last — defer scripts execute in order, and Alpine
          needs clawbackApp() to be defined before it initializes -->
@@ -24,9 +26,16 @@
     </header>
 
     <main class="app-main">
-        <!-- Session picker and playback views will be implemented in later issues -->
-        <div class="placeholder">
-            <p>Clawback is running. UI coming soon.</p>
+        <!-- Session picker (Issue #8) -->
+        <div class="placeholder" x-show="view === 'picker'">
+            <p>Clawback is running. Session picker coming soon.</p>
+        </div>
+
+        <!-- Playback view -->
+        <div class="chat-area"
+             x-ref="chatArea"
+             x-show="view === 'playback'"
+             :class="{ 'chat-area--show-meta': showBeatNumbers }">
         </div>
     </main>
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,9 +1,52 @@
 /**
  * Clawback — Main application state and Alpine.js initialization.
+ *
+ * Wires the parser, playback engine, and renderer together.
+ * Session loading UI comes in Issue #8.
  */
 function clawbackApp() {
     return {
-        sessionName: '',
-        view: 'picker', // 'picker' or 'playback'
+        sessionName: "",
+        view: "picker", // "picker" or "playback"
+        playbackState: "READY",
+        showBeatNumbers: false,
+        _engine: null,
+
+        /**
+         * Load a parsed beat array and start the playback view.
+         * Called by the session picker (Issue #8) or via browser console:
+         *
+         *   const { beats } = ClawbackParser.parseSession(jsonlText);
+         *   document.querySelector('[x-data]').__x.$data.startPlayback(beats, 'My Session');
+         *
+         * @param {Array<Object>} beats - Beat array from ClawbackParser.parseSession()
+         * @param {string} [name] - Session display name
+         */
+        startPlayback(beats, name) {
+            // Tear down previous engine if re-entering
+            if (this._engine) {
+                this._engine.skipToStart();
+                this._engine = null;
+            }
+
+            this.sessionName = name || "";
+            this.view = "playback";
+
+            const chatArea = this.$refs.chatArea;
+            chatArea.innerHTML = "";
+
+            this._engine = new PlaybackEngine({
+                beats: beats,
+                onBeat: (beat) => {
+                    ClawbackRenderer.renderBeat(beat, chatArea);
+                },
+                onRemoveBeat: (beat) => {
+                    ClawbackRenderer.removeBeat(beat, chatArea);
+                },
+                onStateChange: (newState) => {
+                    this.playbackState = newState;
+                },
+            });
+        },
     };
 }

--- a/app/static/js/renderer.js
+++ b/app/static/js/renderer.js
@@ -1,0 +1,71 @@
+/**
+ * Clawback — Chat bubble renderer.
+ *
+ * Renders beat objects as chat bubbles in the DOM. User messages
+ * are right-aligned, assistant messages are left-aligned with
+ * Markdown rendering and syntax highlighting.
+ *
+ * Inner workings (thinking, tool_call, tool_result) are handled
+ * by Issue #5 — this module skips them gracefully.
+ */
+
+/**
+ * Renders a beat as a chat bubble and appends it to the container.
+ * Only handles direct-category beats (user_message, assistant_message).
+ *
+ * @param {Object} beat - Beat object from the parser
+ * @param {HTMLElement} container - Chat area container
+ * @returns {HTMLElement|null} The created bubble element, or null if skipped
+ */
+function renderBeat(beat, container) {
+    if (beat.type !== "user_message" && beat.type !== "assistant_message") {
+        return null;
+    }
+
+    const bubble = document.createElement("div");
+    bubble.classList.add("bubble");
+    bubble.dataset.beatId = String(beat.id);
+
+    if (beat.type === "user_message") {
+        bubble.classList.add("bubble--user");
+        bubble.textContent = beat.content;
+    } else {
+        bubble.classList.add("bubble--assistant");
+        bubble.innerHTML = DOMPurify.sanitize(marked.parse(beat.content));
+        bubble.querySelectorAll("pre code").forEach((block) => {
+            hljs.highlightElement(block);
+        });
+    }
+
+    // Beat number metadata (visibility controlled by CSS on container)
+    const meta = document.createElement("span");
+    meta.classList.add("bubble__meta");
+    meta.textContent = "#" + (beat.id + 1);
+    bubble.appendChild(meta);
+
+    container.appendChild(bubble);
+    return bubble;
+}
+
+/**
+ * Removes a beat's bubble from the container.
+ *
+ * @param {Object} beat - Beat object to remove
+ * @param {HTMLElement} container - Chat area container
+ */
+function removeBeat(beat, container) {
+    const el = container.querySelector('[data-beat-id="' + beat.id + '"]');
+    if (el) {
+        el.remove();
+    }
+}
+
+// Browser export
+if (typeof window !== "undefined") {
+    window.ClawbackRenderer = { renderBeat, removeBeat };
+}
+
+// CommonJS export for Node.js testing
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { renderBeat, removeBeat };
+}

--- a/tests/unit/js/test_renderer.js
+++ b/tests/unit/js/test_renderer.js
@@ -1,0 +1,364 @@
+/**
+ * Clawback — Unit tests for the chat bubble renderer.
+ *
+ * Run with: node tests/unit/js/test_renderer.js
+ * Or via:   make test-js
+ */
+
+const assert = require("node:assert/strict");
+
+// ---------------------------------------------------------------------------
+// DOM mocks — lightweight stand-ins for browser APIs
+// ---------------------------------------------------------------------------
+
+class MockClassList {
+    constructor() {
+        this._set = new Set();
+    }
+    add(...args) {
+        args.forEach((c) => this._set.add(c));
+    }
+    contains(c) {
+        return this._set.has(c);
+    }
+    remove(c) {
+        this._set.delete(c);
+    }
+}
+
+function createElement(tag) {
+    return {
+        tagName: tag.toUpperCase(),
+        classList: new MockClassList(),
+        dataset: {},
+        textContent: "",
+        innerHTML: "",
+        children: [],
+        parentElement: null,
+        appendChild(child) {
+            this.children.push(child);
+            child.parentElement = this;
+            return child;
+        },
+        remove() {
+            if (this.parentElement) {
+                const idx = this.parentElement.children.indexOf(this);
+                if (idx > -1) this.parentElement.children.splice(idx, 1);
+            }
+        },
+        querySelector(sel) {
+            const match = sel.match(/\[data-beat-id="(\d+)"\]/);
+            if (match) {
+                return (
+                    this.children.find(
+                        (c) => String(c.dataset.beatId) === match[1],
+                    ) || null
+                );
+            }
+            return null;
+        },
+        querySelectorAll() {
+            return [];
+        },
+    };
+}
+
+// Set up globals before requiring renderer
+global.document = { createElement };
+
+let markedCalls = [];
+global.marked = {
+    parse: (text) => {
+        markedCalls.push(text);
+        return `<p>${text}</p>`;
+    },
+};
+
+let hljsCalls = [];
+global.hljs = {
+    highlightElement: (el) => {
+        hljsCalls.push(el);
+    },
+};
+
+global.DOMPurify = {
+    sanitize: (html) => html, // pass-through for unit tests
+};
+
+const { renderBeat, removeBeat } = require("../../../app/static/js/renderer.js");
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    // Reset spy state before each test
+    markedCalls = [];
+    hljsCalls = [];
+    try {
+        fn();
+        passed++;
+        console.log(`  \u2713 ${name}`);
+    } catch (err) {
+        failed++;
+        console.log(`  \u2717 ${name}`);
+        console.log(`    ${err.message}`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBeat(id, opts = {}) {
+    return {
+        id,
+        type: opts.type || "assistant_message",
+        category: opts.category || "direct",
+        content: opts.content || "Hello world",
+        metadata: {},
+        duration: 2.0,
+        group_id: null,
+    };
+}
+
+function makeContainer() {
+    return createElement("div");
+}
+
+// ---------------------------------------------------------------------------
+// renderBeat — user messages
+// ---------------------------------------------------------------------------
+console.log("\nrenderBeat — user messages");
+
+test("creates a bubble for user_message", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "user_message", content: "Hi there" });
+    const bubble = renderBeat(beat, container);
+    assert.ok(bubble, "should return the created element");
+    assert.equal(container.children.length, 1);
+});
+
+test("user bubble has correct CSS classes", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "user_message" });
+    const bubble = renderBeat(beat, container);
+    assert.ok(bubble.classList.contains("bubble"));
+    assert.ok(bubble.classList.contains("bubble--user"));
+    assert.ok(!bubble.classList.contains("bubble--assistant"));
+});
+
+test("user message sets textContent (not innerHTML)", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "user_message", content: "Hello <b>world</b>" });
+    const bubble = renderBeat(beat, container);
+    assert.equal(bubble.textContent, "Hello <b>world</b>");
+    // innerHTML should not be set for user messages (XSS safety)
+    assert.equal(bubble.innerHTML, "");
+});
+
+test("user message does not call marked.parse", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "user_message", content: "test" });
+    renderBeat(beat, container);
+    assert.equal(markedCalls.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// renderBeat — assistant messages
+// ---------------------------------------------------------------------------
+console.log("\nrenderBeat — assistant messages");
+
+test("creates a bubble for assistant_message", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "assistant_message", content: "I can help" });
+    const bubble = renderBeat(beat, container);
+    assert.ok(bubble, "should return the created element");
+    assert.equal(container.children.length, 1);
+});
+
+test("assistant bubble has correct CSS classes", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "assistant_message" });
+    const bubble = renderBeat(beat, container);
+    assert.ok(bubble.classList.contains("bubble"));
+    assert.ok(bubble.classList.contains("bubble--assistant"));
+    assert.ok(!bubble.classList.contains("bubble--user"));
+});
+
+test("assistant message renders Markdown via marked.parse", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, {
+        type: "assistant_message",
+        content: "**bold** text",
+    });
+    const bubble = renderBeat(beat, container);
+    assert.equal(markedCalls.length, 1);
+    assert.equal(markedCalls[0], "**bold** text");
+    assert.equal(bubble.innerHTML, "<p>**bold** text</p>");
+});
+
+test("assistant message sanitizes HTML via DOMPurify", () => {
+    const sanitizeCalls = [];
+    global.DOMPurify = {
+        sanitize: (html) => {
+            sanitizeCalls.push(html);
+            return html;
+        },
+    };
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "assistant_message", content: "test" });
+    renderBeat(beat, container);
+    assert.equal(sanitizeCalls.length, 1, "DOMPurify.sanitize should be called");
+    // Restore default mock
+    global.DOMPurify = { sanitize: (html) => html };
+});
+
+test("assistant message calls hljs.highlightElement for code blocks", () => {
+    // Override querySelectorAll to return mock code elements
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "assistant_message", content: "```js\ncode\n```" });
+
+    const mockCodeBlock = createElement("code");
+    const origCreate = global.document.createElement;
+    let bubbleRef = null;
+
+    // Intercept createElement to capture the bubble and override querySelectorAll
+    global.document.createElement = (tag) => {
+        const el = origCreate(tag);
+        if (tag === "div" && !bubbleRef) {
+            bubbleRef = el;
+            el.querySelectorAll = (sel) => {
+                if (sel === "pre code") return [mockCodeBlock];
+                return [];
+            };
+        }
+        return el;
+    };
+
+    renderBeat(beat, container);
+
+    global.document.createElement = origCreate;
+
+    assert.equal(hljsCalls.length, 1, "should call hljs.highlightElement once");
+    assert.equal(hljsCalls[0], mockCodeBlock);
+});
+
+// ---------------------------------------------------------------------------
+// renderBeat — skipped beat types
+// ---------------------------------------------------------------------------
+console.log("\nrenderBeat — skipped types");
+
+test("returns null for thinking beats", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "thinking", category: "inner_working" });
+    const result = renderBeat(beat, container);
+    assert.equal(result, null);
+    assert.equal(container.children.length, 0);
+});
+
+test("returns null for tool_call beats", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "tool_call", category: "inner_working" });
+    const result = renderBeat(beat, container);
+    assert.equal(result, null);
+    assert.equal(container.children.length, 0);
+});
+
+test("returns null for tool_result beats", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "tool_result", category: "inner_working" });
+    const result = renderBeat(beat, container);
+    assert.equal(result, null);
+    assert.equal(container.children.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// renderBeat — beat ID and metadata
+// ---------------------------------------------------------------------------
+console.log("\nrenderBeat — metadata");
+
+test("sets beat ID in dataset", () => {
+    const container = makeContainer();
+    const beat = makeBeat(42, { type: "user_message" });
+    const bubble = renderBeat(beat, container);
+    assert.equal(bubble.dataset.beatId, "42");
+});
+
+test("appends meta element with beat number", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, { type: "user_message" });
+    const bubble = renderBeat(beat, container);
+    const meta = bubble.children.find((c) =>
+        c.classList.contains("bubble__meta"),
+    );
+    assert.ok(meta, "should have a meta child element");
+    assert.equal(meta.textContent, "#1");
+});
+
+test("meta element shows 1-based beat number", () => {
+    const container = makeContainer();
+    const beat = makeBeat(9, { type: "assistant_message" });
+    const bubble = renderBeat(beat, container);
+    const meta = bubble.children.find((c) =>
+        c.classList.contains("bubble__meta"),
+    );
+    assert.equal(meta.textContent, "#10");
+});
+
+// ---------------------------------------------------------------------------
+// renderBeat — ordering
+// ---------------------------------------------------------------------------
+console.log("\nrenderBeat — ordering");
+
+test("messages build downward (newest at bottom)", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, { type: "user_message", content: "first" }), container);
+    renderBeat(makeBeat(1, { type: "assistant_message", content: "second" }), container);
+    renderBeat(makeBeat(2, { type: "user_message", content: "third" }), container);
+
+    assert.equal(container.children.length, 3);
+    assert.equal(container.children[0].dataset.beatId, "0");
+    assert.equal(container.children[1].dataset.beatId, "1");
+    assert.equal(container.children[2].dataset.beatId, "2");
+});
+
+// ---------------------------------------------------------------------------
+// removeBeat
+// ---------------------------------------------------------------------------
+console.log("\nremoveBeat");
+
+test("removes the correct element from container", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, { type: "user_message" }), container);
+    renderBeat(makeBeat(1, { type: "assistant_message" }), container);
+    assert.equal(container.children.length, 2);
+
+    removeBeat({ id: 0 }, container);
+    assert.equal(container.children.length, 1);
+    assert.equal(container.children[0].dataset.beatId, "1");
+});
+
+test("is a no-op when element does not exist", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, { type: "user_message" }), container);
+    removeBeat({ id: 99 }, container);
+    assert.equal(container.children.length, 1, "should not remove anything");
+});
+
+test("removes the last of multiple elements", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, { type: "user_message" }), container);
+    renderBeat(makeBeat(1, { type: "assistant_message" }), container);
+    renderBeat(makeBeat(2, { type: "user_message" }), container);
+
+    removeBeat({ id: 2 }, container);
+    assert.equal(container.children.length, 2);
+    assert.equal(container.children[0].dataset.beatId, "0");
+    assert.equal(container.children[1].dataset.beatId, "1");
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -13,10 +13,12 @@ def test_index_loads_all_required_scripts(client):
     html = client.get("/").data.decode()
     assert "parser.js" in html, "parser.js must be loaded"
     assert "playback.js" in html, "playback.js must be loaded"
+    assert "renderer.js" in html, "renderer.js must be loaded"
     assert "app.js" in html, "app.js must be loaded"
     assert "alpinejs" in html, "Alpine.js must be loaded"
     assert "marked" in html, "marked.js must be loaded"
     assert "highlight" in html, "highlight.js must be loaded"
+    assert "dompurify" in html.lower(), "DOMPurify must be loaded"
 
 
 def test_index_script_load_order(client):
@@ -32,6 +34,8 @@ def test_index_script_load_order(client):
             return "parser"
         if "playback.js" in src:
             return "playback"
+        if "renderer.js" in src:
+            return "renderer"
         if "app.js" in src:
             return "app"
         if "alpinejs" in src:
@@ -40,13 +44,35 @@ def test_index_script_load_order(client):
             return "marked"
         if "highlight" in src:
             return "highlight"
+        if "dompurify" in src.lower() or "purify" in src.lower():
+            return "dompurify"
         return src
 
     order = [lib_name(s) for s in script_tags]
 
-    assert order.index("parser") < order.index("playback"), "parser.js must load before playback.js"
-    assert order.index("playback") < order.index("app"), "playback.js must load before app.js"
-    assert order.index("app") < order.index("alpine"), "app.js must load before Alpine.js"
+    # CDN libs must load before modules that depend on them
+    assert order.index("marked") < order.index("renderer"), (
+        "marked must load before renderer.js"
+    )
+    assert order.index("highlight") < order.index("renderer"), (
+        "highlight.js must load before renderer.js"
+    )
+    assert order.index("dompurify") < order.index("renderer"), (
+        "DOMPurify must load before renderer.js"
+    )
+    # Clawback modules in dependency order
+    assert order.index("parser") < order.index("playback"), (
+        "parser.js must load before playback.js"
+    )
+    assert order.index("playback") < order.index("renderer"), (
+        "playback.js must load before renderer.js"
+    )
+    assert order.index("renderer") < order.index("app"), (
+        "renderer.js must load before app.js"
+    )
+    assert order.index("app") < order.index("alpine"), (
+        "app.js must load before Alpine.js"
+    )
 
 
 def test_index_cdn_versions_are_pinned(client):


### PR DESCRIPTION
## Summary
- `renderer.js` with `renderBeat`/`removeBeat` — user bubbles right-aligned, assistant bubbles left-aligned with Markdown + syntax highlighting
- XSS protection via DOMPurify (new CDN dependency, pinned @3.2.3)
- CSS: bubble styles, Markdown typography (headings, code, tables, blockquotes, lists), `fadeSlideUp` animation
- `app.js` wires renderer to PlaybackEngine callbacks with engine cleanup for re-entry
- Optional beat numbers via CSS container class toggle (`chat-area--show-meta`)
- 19 unit tests with lightweight DOM mocks; load-order tests guard CDN → module dependencies

## Test plan
- [x] `node tests/unit/js/test_renderer.js` — 19/19 pass
- [x] `node tests/unit/js/test_playback.js` — 56/56 pass
- [x] `node tests/unit/js/test_parser.js` — 34/34 pass
- [x] `pytest tests/unit/ -v` — 7/7 pass (including DOMPurify + renderer load-order assertions)
- [x] `make lint` — clean
- [ ] CI pipeline passes

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)