### PR TITLE
feat(renderer): implement collapsible inner working summary cards

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -246,3 +246,119 @@ body {
     border-top: 1px solid var(--color-border);
     margin: 0.75em 0;
 }
+
+/* -----------------------------------------------------------------------
+   Inner workings cards
+   ----------------------------------------------------------------------- */
+.iw-card {
+    align-self: flex-start;
+    width: 80%;
+    background-color: var(--color-inner-workings);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    animation: fadeSlideUp 0.3s ease-out;
+    overflow: hidden;
+}
+
+.iw-card__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.iw-card__header:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.iw-card__icon {
+    font-size: 1.1rem;
+    flex-shrink: 0;
+}
+
+.iw-card__summary {
+    flex: 1;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+}
+
+.iw-card__toggle {
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    padding: 4px 10px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color 0.2s, border-color 0.2s;
+}
+
+.iw-card__toggle:hover {
+    color: var(--color-text);
+    border-color: var(--color-text-muted);
+}
+
+.iw-card__body {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease-in-out;
+}
+
+/* Items within the expanded card */
+.iw-item {
+    padding: 8px 16px;
+    border-top: 1px solid var(--color-border);
+}
+
+.iw-item__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.iw-item__icon {
+    font-size: 1rem;
+    flex-shrink: 0;
+}
+
+.iw-item__label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--color-text);
+}
+
+.iw-item__content {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    color: var(--color-text-muted);
+}
+
+.iw-item__content pre {
+    margin: 0;
+    border-radius: 6px;
+    overflow-x: auto;
+}
+
+.iw-item__content pre code {
+    display: block;
+    padding: 8px 12px;
+    background-color: rgba(0, 0, 0, 0.3);
+    font-size: 0.9em;
+    line-height: 1.5;
+}
+
+.iw-item__content--scrollable {
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.iw-item--error .iw-item__label {
+    color: var(--color-accent);
+}

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -34,6 +34,7 @@ function clawbackApp() {
 
             const chatArea = this.$refs.chatArea;
             chatArea.innerHTML = "";
+            ClawbackRenderer.resetGroups();
 
             this._engine = new PlaybackEngine({
                 beats: beats,

--- a/app/static/js/renderer.js
+++ b/app/static/js/renderer.js
@@ -1,23 +1,32 @@
 /**
- * Clawback — Chat bubble renderer.
+ * Clawback — Chat bubble and inner workings renderer.
  *
- * Renders beat objects as chat bubbles in the DOM. User messages
- * are right-aligned, assistant messages are left-aligned with
+ * Renders beat objects as chat bubbles or collapsible inner workings cards.
+ * User messages are right-aligned, assistant messages are left-aligned with
  * Markdown rendering and syntax highlighting.
  *
- * Inner workings (thinking, tool_call, tool_result) are handled
- * by Issue #5 — this module skips them gracefully.
+ * Inner workings (thinking, tool_call, tool_result) are grouped by the
+ * parser's group_id into collapsible summary cards.
  */
 
+/** @type {Map<number, Object>} Active inner workings groups by group_id */
+const _activeGroups = new Map();
+
 /**
- * Renders a beat as a chat bubble and appends it to the container.
- * Only handles direct-category beats (user_message, assistant_message).
+ * Renders a beat and appends it to the container.
+ *
+ * Direct-category beats become chat bubbles. Inner working beats are
+ * grouped into collapsible summary cards based on group_id.
  *
  * @param {Object} beat - Beat object from the parser
  * @param {HTMLElement} container - Chat area container
- * @returns {HTMLElement|null} The created bubble element, or null if skipped
+ * @returns {HTMLElement|null} The created/updated element, or null if skipped
  */
 function renderBeat(beat, container) {
+    if (beat.category === "inner_working" && beat.group_id !== null) {
+        return _renderInnerWorkingBeat(beat, container);
+    }
+
     if (beat.type !== "user_message" && beat.type !== "assistant_message") {
         return null;
     }
@@ -48,24 +57,257 @@ function renderBeat(beat, container) {
 }
 
 /**
- * Removes a beat's bubble from the container.
+ * Removes a beat from the container.
+ * Handles both direct bubbles and inner workings group items.
  *
  * @param {Object} beat - Beat object to remove
  * @param {HTMLElement} container - Chat area container
  */
 function removeBeat(beat, container) {
+    if (beat.category === "inner_working" && beat.group_id !== null) {
+        const group = _activeGroups.get(beat.group_id);
+        if (group && group.items.has(beat.id)) {
+            _removeItemFromGroup(beat, group);
+            return;
+        }
+    }
+
     const el = container.querySelector('[data-beat-id="' + beat.id + '"]');
     if (el) {
         el.remove();
     }
 }
 
+/**
+ * Toggles all inner workings cards expanded or collapsed.
+ *
+ * @param {HTMLElement} _container - Chat area container (unused, API symmetry)
+ * @param {boolean} expanded - true to expand, false to collapse
+ */
+function toggleAllInnerWorkings(_container, expanded) {
+    for (const group of _activeGroups.values()) {
+        if (group.expanded !== expanded) {
+            _toggleCard(group);
+        }
+    }
+}
+
+/**
+ * Clears all tracked inner workings groups.
+ * Call when starting a new playback session.
+ *
+ * Important: the caller must clear the container DOM (e.g. innerHTML = "")
+ * before calling this, otherwise orphaned group cards remain visible.
+ */
+function resetGroups() {
+    _activeGroups.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Internal — inner workings rendering
+// ---------------------------------------------------------------------------
+
+function _renderInnerWorkingBeat(beat, container) {
+    let group = _activeGroups.get(beat.group_id);
+    if (!group) {
+        group = _createGroupCard(beat.group_id, container);
+        _activeGroups.set(beat.group_id, group);
+    }
+    _addItemToGroup(beat, group);
+    return group.card;
+}
+
+function _createGroupCard(groupId, container) {
+    const card = document.createElement("div");
+    card.classList.add("iw-card", "iw-card--collapsed");
+    card.dataset.groupId = String(groupId);
+
+    const header = document.createElement("div");
+    header.classList.add("iw-card__header");
+
+    const icon = document.createElement("span");
+    icon.classList.add("iw-card__icon");
+    icon.textContent = "\u2699";
+
+    const summary = document.createElement("span");
+    summary.classList.add("iw-card__summary");
+    summary.textContent = "Inner workings";
+
+    const toggleBtn = document.createElement("button");
+    toggleBtn.classList.add("iw-card__toggle");
+    toggleBtn.textContent = "\u25B6 Show";
+
+    header.appendChild(icon);
+    header.appendChild(summary);
+    header.appendChild(toggleBtn);
+
+    const body = document.createElement("div");
+    body.classList.add("iw-card__body");
+
+    card.appendChild(header);
+    card.appendChild(body);
+    container.appendChild(card);
+
+    const group = {
+        card,
+        header,
+        body,
+        summary,
+        toggleBtn,
+        items: new Map(),
+        counts: { thinking: 0, tool_call: 0, tool_result: 0 },
+        expanded: false,
+    };
+
+    toggleBtn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        _toggleCard(group);
+    });
+
+    header.addEventListener("click", function () {
+        _toggleCard(group);
+    });
+
+    return group;
+}
+
+function _addItemToGroup(beat, group) {
+    const item = document.createElement("div");
+    item.classList.add("iw-item");
+    item.dataset.beatId = String(beat.id);
+
+    const itemHeader = document.createElement("div");
+    itemHeader.classList.add("iw-item__header");
+
+    const icon = document.createElement("span");
+    icon.classList.add("iw-item__icon");
+
+    const label = document.createElement("span");
+    label.classList.add("iw-item__label");
+
+    const content = document.createElement("div");
+    content.classList.add("iw-item__content");
+
+    if (beat.type === "thinking") {
+        icon.textContent = "\uD83D\uDCAD";
+        label.textContent = "Thinking";
+        content.textContent = beat.content;
+    } else if (beat.type === "tool_call") {
+        icon.textContent = "\uD83D\uDD27";
+        const toolName = (beat.metadata && beat.metadata.tool_name) || "Unknown";
+        label.textContent = "Tool Call: " + toolName;
+        const tcPre = document.createElement("pre");
+        const tcCode = document.createElement("code");
+        tcCode.textContent = beat.content;
+        tcPre.appendChild(tcCode);
+        content.appendChild(tcPre);
+        hljs.highlightElement(tcCode);
+    } else if (beat.type === "tool_result") {
+        icon.textContent = "\uD83D\uDCCB";
+        label.textContent = "Tool Result";
+        if (beat.metadata && beat.metadata.is_error) {
+            label.textContent += " (Error)";
+            item.classList.add("iw-item--error");
+        }
+        content.classList.add("iw-item__content--scrollable");
+        const trPre = document.createElement("pre");
+        const trCode = document.createElement("code");
+        trCode.textContent = beat.content;
+        trPre.appendChild(trCode);
+        content.appendChild(trPre);
+        hljs.highlightElement(trCode);
+    }
+
+    itemHeader.appendChild(icon);
+    itemHeader.appendChild(label);
+
+    item.appendChild(itemHeader);
+    item.appendChild(content);
+
+    group.body.appendChild(item);
+    group.items.set(beat.id, item);
+
+    if (beat.type in group.counts) {
+        group.counts[beat.type]++;
+    }
+    _updateSummary(group);
+
+    // Update max-height if card is currently expanded
+    if (group.expanded) {
+        group.body.style.maxHeight = group.body.scrollHeight + "px";
+    }
+}
+
+function _updateSummary(group) {
+    const parts = [];
+    if (group.counts.thinking > 0) {
+        const n = group.counts.thinking;
+        parts.push(n + " thought" + (n !== 1 ? "s" : ""));
+    }
+    if (group.counts.tool_call > 0) {
+        const n = group.counts.tool_call;
+        parts.push(n + " tool call" + (n !== 1 ? "s" : ""));
+    }
+    if (group.counts.tool_result > 0) {
+        const n = group.counts.tool_result;
+        parts.push(n + " result" + (n !== 1 ? "s" : ""));
+    }
+    group.summary.textContent = "Inner workings: " + parts.join(", ");
+}
+
+function _toggleCard(group) {
+    group.expanded = !group.expanded;
+    if (group.expanded) {
+        group.card.classList.remove("iw-card--collapsed");
+        group.card.classList.add("iw-card--expanded");
+        group.body.style.maxHeight = group.body.scrollHeight + "px";
+        group.toggleBtn.textContent = "\u25BC Hide";
+    } else {
+        group.card.classList.remove("iw-card--expanded");
+        group.card.classList.add("iw-card--collapsed");
+        group.body.style.maxHeight = "0";
+        group.toggleBtn.textContent = "\u25B6 Show";
+    }
+}
+
+function _removeItemFromGroup(beat, group) {
+    const item = group.items.get(beat.id);
+    if (!item) return;
+
+    item.remove();
+    group.items.delete(beat.id);
+
+    if (beat.type in group.counts) {
+        group.counts[beat.type]--;
+    }
+
+    if (group.items.size === 0) {
+        group.card.remove();
+        _activeGroups.delete(beat.group_id);
+    } else {
+        _updateSummary(group);
+        if (group.expanded) {
+            group.body.style.maxHeight = group.body.scrollHeight + "px";
+        }
+    }
+}
+
 // Browser export
 if (typeof window !== "undefined") {
-    window.ClawbackRenderer = { renderBeat, removeBeat };
+    window.ClawbackRenderer = {
+        renderBeat,
+        removeBeat,
+        toggleAllInnerWorkings,
+        resetGroups,
+    };
 }
 
 // CommonJS export for Node.js testing
 if (typeof module !== "undefined" && module.exports) {
-    module.exports = { renderBeat, removeBeat };
+    module.exports = {
+        renderBeat,
+        removeBeat,
+        toggleAllInnerWorkings,
+        resetGroups,
+    };
 }

--- a/tests/unit/js/test_renderer.js
+++ b/tests/unit/js/test_renderer.js
@@ -1,5 +1,5 @@
 /**
- * Clawback — Unit tests for the chat bubble renderer.
+ * Clawback — Unit tests for the chat bubble and inner workings renderer.
  *
  * Run with: node tests/unit/js/test_renderer.js
  * Or via:   make test-js
@@ -27,6 +27,7 @@ class MockClassList {
 }
 
 function createElement(tag) {
+    const _listeners = {};
     return {
         tagName: tag.toUpperCase(),
         classList: new MockClassList(),
@@ -35,6 +36,16 @@ function createElement(tag) {
         innerHTML: "",
         children: [],
         parentElement: null,
+        style: {},
+        scrollHeight: 200,
+        addEventListener(event, handler) {
+            if (!_listeners[event]) _listeners[event] = [];
+            _listeners[event].push(handler);
+        },
+        click() {
+            const handlers = _listeners["click"] || [];
+            handlers.forEach((fn) => fn({ stopPropagation() {} }));
+        },
         appendChild(child) {
             this.children.push(child);
             child.parentElement = this;
@@ -85,15 +96,21 @@ global.DOMPurify = {
     sanitize: (html) => html, // pass-through for unit tests
 };
 
-const { renderBeat, removeBeat } = require("../../../app/static/js/renderer.js");
+const {
+    renderBeat,
+    removeBeat,
+    toggleAllInnerWorkings,
+    resetGroups,
+} = require("../../../app/static/js/renderer.js");
 
 let passed = 0;
 let failed = 0;
 
 function test(name, fn) {
-    // Reset spy state before each test
+    // Reset spy state and inner workings groups before each test
     markedCalls = [];
     hljsCalls = [];
+    resetGroups();
     try {
         fn();
         passed++;
@@ -115,9 +132,9 @@ function makeBeat(id, opts = {}) {
         type: opts.type || "assistant_message",
         category: opts.category || "direct",
         content: opts.content || "Hello world",
-        metadata: {},
+        metadata: opts.metadata || {},
         duration: 2.0,
-        group_id: null,
+        group_id: opts.group_id !== undefined ? opts.group_id : null,
     };
 }
 
@@ -244,11 +261,11 @@ test("assistant message calls hljs.highlightElement for code blocks", () => {
 });
 
 // ---------------------------------------------------------------------------
-// renderBeat — skipped beat types
+// renderBeat — skipped beat types (inner_working with no group_id)
 // ---------------------------------------------------------------------------
 console.log("\nrenderBeat — skipped types");
 
-test("returns null for thinking beats", () => {
+test("returns null for thinking beats without group_id", () => {
     const container = makeContainer();
     const beat = makeBeat(0, { type: "thinking", category: "inner_working" });
     const result = renderBeat(beat, container);
@@ -256,7 +273,7 @@ test("returns null for thinking beats", () => {
     assert.equal(container.children.length, 0);
 });
 
-test("returns null for tool_call beats", () => {
+test("returns null for tool_call beats without group_id", () => {
     const container = makeContainer();
     const beat = makeBeat(0, { type: "tool_call", category: "inner_working" });
     const result = renderBeat(beat, container);
@@ -264,7 +281,7 @@ test("returns null for tool_call beats", () => {
     assert.equal(container.children.length, 0);
 });
 
-test("returns null for tool_result beats", () => {
+test("returns null for tool_result beats without group_id", () => {
     const container = makeContainer();
     const beat = makeBeat(0, { type: "tool_result", category: "inner_working" });
     const result = renderBeat(beat, container);
@@ -323,9 +340,9 @@ test("messages build downward (newest at bottom)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// removeBeat
+// removeBeat — direct beats
 // ---------------------------------------------------------------------------
-console.log("\nremoveBeat");
+console.log("\nremoveBeat — direct beats");
 
 test("removes the correct element from container", () => {
     const container = makeContainer();
@@ -355,6 +372,685 @@ test("removes the last of multiple elements", () => {
     assert.equal(container.children.length, 2);
     assert.equal(container.children[0].dataset.beatId, "0");
     assert.equal(container.children[1].dataset.beatId, "1");
+});
+
+// ---------------------------------------------------------------------------
+// renderBeat — inner workings (group creation)
+// ---------------------------------------------------------------------------
+console.log("\nrenderBeat — inner workings (group creation)");
+
+test("creates a group card for first inner_working beat", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        content: "Let me think...",
+        group_id: 1,
+    });
+    const card = renderBeat(beat, container);
+    assert.ok(card, "should return the group card element");
+    assert.equal(container.children.length, 1);
+    assert.ok(card.classList.contains("iw-card"));
+    assert.ok(card.classList.contains("iw-card--collapsed"));
+});
+
+test("adds second beat to same group when group_id matches", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        content: "thought 1",
+        group_id: 1,
+    }), container);
+    const card2 = renderBeat(makeBeat(1, {
+        type: "tool_call",
+        category: "inner_working",
+        content: "ls -la",
+        group_id: 1,
+        metadata: { tool_name: "Bash" },
+    }), container);
+
+    // Still only one card in container
+    assert.equal(container.children.length, 1);
+    // Card body has two items
+    const body = card2.children.find((c) => c.classList.contains("iw-card__body"));
+    assert.equal(body.children.length, 2);
+});
+
+test("different group_id creates a new card", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+    renderBeat(makeBeat(1, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 2,
+    }), container);
+
+    assert.equal(container.children.length, 2);
+    assert.equal(container.children[0].dataset.groupId, "1");
+    assert.equal(container.children[1].dataset.groupId, "2");
+});
+
+test("card starts in collapsed state", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+    assert.ok(card.classList.contains("iw-card--collapsed"));
+    assert.ok(!card.classList.contains("iw-card--expanded"));
+});
+
+test("group card has header with icon, summary, and toggle button", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    const header = card.children.find((c) =>
+        c.classList.contains("iw-card__header"),
+    );
+    assert.ok(header, "should have a header");
+
+    const icon = header.children.find((c) =>
+        c.classList.contains("iw-card__icon"),
+    );
+    assert.ok(icon, "header should have an icon");
+    assert.equal(icon.textContent, "\u2699");
+
+    const summary = header.children.find((c) =>
+        c.classList.contains("iw-card__summary"),
+    );
+    assert.ok(summary, "header should have a summary");
+
+    const toggle = header.children.find((c) =>
+        c.classList.contains("iw-card__toggle"),
+    );
+    assert.ok(toggle, "header should have a toggle button");
+});
+
+// ---------------------------------------------------------------------------
+// renderBeat — inner workings (summary counts)
+// ---------------------------------------------------------------------------
+console.log("\nrenderBeat — inner workings (summary counts)");
+
+test("summary shows singular count for one thinking beat", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    const header = card.children.find((c) =>
+        c.classList.contains("iw-card__header"),
+    );
+    const summary = header.children.find((c) =>
+        c.classList.contains("iw-card__summary"),
+    );
+    assert.ok(summary.textContent.includes("1 thought"));
+    assert.ok(!summary.textContent.includes("thoughts"));
+});
+
+test("summary shows plural count for multiple thinking beats", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+    const card = renderBeat(makeBeat(1, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    const header = card.children.find((c) =>
+        c.classList.contains("iw-card__header"),
+    );
+    const summary = header.children.find((c) =>
+        c.classList.contains("iw-card__summary"),
+    );
+    assert.ok(summary.textContent.includes("2 thoughts"));
+});
+
+test("summary shows combined counts for mixed types", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+    renderBeat(makeBeat(1, {
+        type: "tool_call",
+        category: "inner_working",
+        group_id: 1,
+        metadata: { tool_name: "Bash" },
+    }), container);
+    renderBeat(makeBeat(2, {
+        type: "tool_call",
+        category: "inner_working",
+        group_id: 1,
+        metadata: { tool_name: "Read" },
+    }), container);
+    const card = renderBeat(makeBeat(3, {
+        type: "tool_result",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    const header = card.children.find((c) =>
+        c.classList.contains("iw-card__header"),
+    );
+    const summary = header.children.find((c) =>
+        c.classList.contains("iw-card__summary"),
+    );
+    assert.ok(summary.textContent.includes("1 thought"));
+    assert.ok(summary.textContent.includes("2 tool calls"));
+    assert.ok(summary.textContent.includes("1 result"));
+});
+
+// ---------------------------------------------------------------------------
+// renderBeat — inner workings (item content)
+// ---------------------------------------------------------------------------
+console.log("\nrenderBeat — inner workings (item content)");
+
+test("thinking item has correct icon and label", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        content: "I need to check...",
+        group_id: 1,
+    }), container);
+
+    const body = card.children.find((c) => c.classList.contains("iw-card__body"));
+    const item = body.children[0];
+    const itemHeader = item.children.find((c) =>
+        c.classList.contains("iw-item__header"),
+    );
+
+    const icon = itemHeader.children.find((c) =>
+        c.classList.contains("iw-item__icon"),
+    );
+    assert.equal(icon.textContent, "\uD83D\uDCAD");
+
+    const label = itemHeader.children.find((c) =>
+        c.classList.contains("iw-item__label"),
+    );
+    assert.equal(label.textContent, "Thinking");
+});
+
+test("thinking item sets content as textContent", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        content: "The user wants me to...",
+        group_id: 1,
+    }), container);
+
+    const body = card.children.find((c) => c.classList.contains("iw-card__body"));
+    const item = body.children[0];
+    const content = item.children.find((c) =>
+        c.classList.contains("iw-item__content"),
+    );
+    assert.equal(content.textContent, "The user wants me to...");
+});
+
+test("tool_call item shows tool name in label", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "tool_call",
+        category: "inner_working",
+        content: "ls -la /home",
+        group_id: 1,
+        metadata: { tool_name: "Bash" },
+    }), container);
+
+    const body = card.children.find((c) => c.classList.contains("iw-card__body"));
+    const item = body.children[0];
+    const itemHeader = item.children.find((c) =>
+        c.classList.contains("iw-item__header"),
+    );
+
+    const icon = itemHeader.children.find((c) =>
+        c.classList.contains("iw-item__icon"),
+    );
+    assert.equal(icon.textContent, "\uD83D\uDD27");
+
+    const label = itemHeader.children.find((c) =>
+        c.classList.contains("iw-item__label"),
+    );
+    assert.equal(label.textContent, "Tool Call: Bash");
+});
+
+test("tool_result item has correct icon", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "tool_result",
+        category: "inner_working",
+        content: "total 40\ndrwxr-xr-x...",
+        group_id: 1,
+    }), container);
+
+    const body = card.children.find((c) => c.classList.contains("iw-card__body"));
+    const item = body.children[0];
+    const itemHeader = item.children.find((c) =>
+        c.classList.contains("iw-item__header"),
+    );
+    const icon = itemHeader.children.find((c) =>
+        c.classList.contains("iw-item__icon"),
+    );
+    assert.equal(icon.textContent, "\uD83D\uDCCB");
+});
+
+test("tool_result error shows error indicator in label", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "tool_result",
+        category: "inner_working",
+        content: "command not found",
+        group_id: 1,
+        metadata: { is_error: true },
+    }), container);
+
+    const body = card.children.find((c) => c.classList.contains("iw-card__body"));
+    const item = body.children[0];
+
+    assert.ok(item.classList.contains("iw-item--error"));
+
+    const itemHeader = item.children.find((c) =>
+        c.classList.contains("iw-item__header"),
+    );
+    const label = itemHeader.children.find((c) =>
+        c.classList.contains("iw-item__label"),
+    );
+    assert.ok(label.textContent.includes("Error"));
+});
+
+test("tool_result content has scrollable class", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "tool_result",
+        category: "inner_working",
+        content: "output...",
+        group_id: 1,
+    }), container);
+
+    const body = card.children.find((c) => c.classList.contains("iw-card__body"));
+    const item = body.children[0];
+    const content = item.children.find((c) =>
+        c.classList.contains("iw-item__content"),
+    );
+    assert.ok(content.classList.contains("iw-item__content--scrollable"));
+});
+
+test("tool_call content gets syntax highlighting", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "tool_call",
+        category: "inner_working",
+        content: "ls -la /home",
+        group_id: 1,
+        metadata: { tool_name: "Bash" },
+    }), container);
+
+    assert.ok(hljsCalls.length > 0, "hljs.highlightElement should be called");
+});
+
+test("tool_result content gets syntax highlighting", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "tool_result",
+        category: "inner_working",
+        content: "file output here",
+        group_id: 1,
+    }), container);
+
+    assert.ok(hljsCalls.length > 0, "hljs.highlightElement should be called");
+});
+
+test("each item has data-beat-id set", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(7, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    const body = card.children.find((c) => c.classList.contains("iw-card__body"));
+    assert.equal(body.children[0].dataset.beatId, "7");
+});
+
+// ---------------------------------------------------------------------------
+// inner workings — toggle
+// ---------------------------------------------------------------------------
+console.log("\ninner workings — toggle");
+
+test("clicking toggle button expands card", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    const header = card.children.find((c) =>
+        c.classList.contains("iw-card__header"),
+    );
+    const toggleBtn = header.children.find((c) =>
+        c.classList.contains("iw-card__toggle"),
+    );
+
+    // Click to expand
+    toggleBtn.click();
+    assert.ok(card.classList.contains("iw-card--expanded"));
+    assert.ok(!card.classList.contains("iw-card--collapsed"));
+    assert.ok(toggleBtn.textContent.includes("Hide"));
+});
+
+test("clicking toggle again collapses card", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    const header = card.children.find((c) =>
+        c.classList.contains("iw-card__header"),
+    );
+    const toggleBtn = header.children.find((c) =>
+        c.classList.contains("iw-card__toggle"),
+    );
+
+    // Expand then collapse
+    toggleBtn.click();
+    toggleBtn.click();
+    assert.ok(card.classList.contains("iw-card--collapsed"));
+    assert.ok(!card.classList.contains("iw-card--expanded"));
+    assert.ok(toggleBtn.textContent.includes("Show"));
+});
+
+test("clicking header also toggles card", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    const header = card.children.find((c) =>
+        c.classList.contains("iw-card__header"),
+    );
+
+    // Click header to expand
+    header.click();
+    assert.ok(card.classList.contains("iw-card--expanded"));
+});
+
+test("expanded card sets max-height on body", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    const header = card.children.find((c) =>
+        c.classList.contains("iw-card__header"),
+    );
+    const body = card.children.find((c) =>
+        c.classList.contains("iw-card__body"),
+    );
+    const toggleBtn = header.children.find((c) =>
+        c.classList.contains("iw-card__toggle"),
+    );
+
+    toggleBtn.click();
+    assert.equal(body.style.maxHeight, body.scrollHeight + "px");
+});
+
+test("collapsed card sets max-height to 0", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    const header = card.children.find((c) =>
+        c.classList.contains("iw-card__header"),
+    );
+    const body = card.children.find((c) =>
+        c.classList.contains("iw-card__body"),
+    );
+    const toggleBtn = header.children.find((c) =>
+        c.classList.contains("iw-card__toggle"),
+    );
+
+    // Expand then collapse
+    toggleBtn.click();
+    toggleBtn.click();
+    assert.equal(body.style.maxHeight, "0");
+});
+
+// ---------------------------------------------------------------------------
+// toggleAllInnerWorkings
+// ---------------------------------------------------------------------------
+console.log("\ntoggleAllInnerWorkings");
+
+test("expands all collapsed cards", () => {
+    const container = makeContainer();
+    const card1 = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+    const card2 = renderBeat(makeBeat(1, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 2,
+    }), container);
+
+    toggleAllInnerWorkings(container, true);
+
+    assert.ok(card1.classList.contains("iw-card--expanded"));
+    assert.ok(card2.classList.contains("iw-card--expanded"));
+});
+
+test("collapses all expanded cards", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+    renderBeat(makeBeat(1, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 2,
+    }), container);
+
+    // Expand all then collapse all
+    toggleAllInnerWorkings(container, true);
+    toggleAllInnerWorkings(container, false);
+
+    assert.equal(container.children.length, 2);
+    assert.ok(container.children[0].classList.contains("iw-card--collapsed"));
+    assert.ok(container.children[1].classList.contains("iw-card--collapsed"));
+});
+
+test("does not toggle cards already in desired state", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    // Already collapsed — toggle to collapsed should be a no-op
+    toggleAllInnerWorkings(container, false);
+    assert.ok(card.classList.contains("iw-card--collapsed"));
+});
+
+// ---------------------------------------------------------------------------
+// removeBeat — inner workings
+// ---------------------------------------------------------------------------
+console.log("\nremoveBeat — inner workings");
+
+test("removes item from group", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+    const card = renderBeat(makeBeat(1, {
+        type: "tool_call",
+        category: "inner_working",
+        group_id: 1,
+        metadata: { tool_name: "Bash" },
+    }), container);
+
+    const body = card.children.find((c) => c.classList.contains("iw-card__body"));
+    assert.equal(body.children.length, 2);
+
+    removeBeat({
+        id: 1,
+        type: "tool_call",
+        category: "inner_working",
+        group_id: 1,
+    }, container);
+
+    assert.equal(body.children.length, 1);
+    assert.equal(container.children.length, 1, "card should still exist");
+});
+
+test("removes entire card when last item removed", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+    assert.equal(container.children.length, 1);
+
+    removeBeat({
+        id: 0,
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }, container);
+
+    assert.equal(container.children.length, 0, "card should be removed");
+});
+
+test("updates summary after item removal", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+    renderBeat(makeBeat(1, {
+        type: "tool_call",
+        category: "inner_working",
+        group_id: 1,
+        metadata: { tool_name: "Bash" },
+    }), container);
+    const card = renderBeat(makeBeat(2, {
+        type: "tool_call",
+        category: "inner_working",
+        group_id: 1,
+        metadata: { tool_name: "Read" },
+    }), container);
+
+    // Remove one tool_call
+    removeBeat({
+        id: 2,
+        type: "tool_call",
+        category: "inner_working",
+        group_id: 1,
+    }, container);
+
+    const header = card.children.find((c) =>
+        c.classList.contains("iw-card__header"),
+    );
+    const summary = header.children.find((c) =>
+        c.classList.contains("iw-card__summary"),
+    );
+    assert.ok(summary.textContent.includes("1 thought"));
+    assert.ok(summary.textContent.includes("1 tool call"));
+    assert.ok(!summary.textContent.includes("2 tool calls"));
+});
+
+// ---------------------------------------------------------------------------
+// resetGroups
+// ---------------------------------------------------------------------------
+console.log("\nresetGroups");
+
+test("clears all tracked groups", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+
+    resetGroups();
+
+    // After reset, a new beat with same group_id creates a fresh card
+    const container2 = makeContainer();
+    const card = renderBeat(makeBeat(1, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container2);
+
+    // Should be a new card, not added to the old one
+    assert.equal(container2.children.length, 1);
+    const body = card.children.find((c) => c.classList.contains("iw-card__body"));
+    assert.equal(body.children.length, 1, "should have only the new item");
+});
+
+// ---------------------------------------------------------------------------
+// Integration — mixed direct and inner working beats
+// ---------------------------------------------------------------------------
+console.log("\nintegration — mixed beat types");
+
+test("interleaves bubbles and inner workings cards correctly", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, { type: "user_message", content: "Hello" }), container);
+    renderBeat(makeBeat(1, {
+        type: "thinking",
+        category: "inner_working",
+        group_id: 1,
+    }), container);
+    renderBeat(makeBeat(2, {
+        type: "tool_call",
+        category: "inner_working",
+        group_id: 1,
+        metadata: { tool_name: "Bash" },
+    }), container);
+    renderBeat(makeBeat(3, {
+        type: "assistant_message",
+        content: "Here you go",
+    }), container);
+
+    // user bubble + iw card + assistant bubble = 3 container children
+    assert.equal(container.children.length, 3);
+    assert.ok(container.children[0].classList.contains("bubble--user"));
+    assert.ok(container.children[1].classList.contains("iw-card"));
+    assert.ok(container.children[2].classList.contains("bubble--assistant"));
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Group consecutive inner_working beats into collapsible summary cards using the parser's `group_id`
- Collapsed cards show counts ("N thoughts, N tool calls, N results"); expanded cards show full content with type icons (💭🔧📋)
- Tool call/result content gets syntax highlighting via hljs; tool results are scrollable (max-height 300px)
- Per-card toggle via click on header or button, plus `toggleAllInnerWorkings()` for global control
- Smooth collapse/expand animation via CSS `max-height` transition with `ease-in-out` timing
- 30 new tests (49 renderer tests total), all 146 tests passing

Closes #5

## Test plan

- [x] All 49 renderer JS tests pass (group creation, summary counts, item content, toggle, removal, reset, integration)
- [x] All 56 playback JS tests pass (unchanged)
- [x] All 34 parser JS tests pass (unchanged)
- [x] All 7 Python tests pass (unchanged)
- [x] `make lint` passes
- [x] Code review agent run — findings addressed (var→const, ease-out→ease-in-out, JSDoc clarification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)