### PR TITLE
feat(toolbar): implement persistent bottom toolbar with transport and speed controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ test-js:
 	node tests/unit/js/test_playback.js
 	node tests/unit/js/test_renderer.js
 	node tests/unit/js/test_scroller.js
+	node tests/unit/js/test_app.js
 
 test-integration:
 	python -m pytest tests/integration/ -v

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -364,11 +364,102 @@ body {
 }
 
 /* -----------------------------------------------------------------------
+   Alpine.js cloak — hide elements until Alpine initializes
+   ----------------------------------------------------------------------- */
+[x-cloak] {
+    display: none !important;
+}
+
+/* -----------------------------------------------------------------------
+   Playback toolbar
+   ----------------------------------------------------------------------- */
+.toolbar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: var(--toolbar-height);
+    background-color: var(--color-surface);
+    border-top: 1px solid var(--color-border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 0 16px;
+    z-index: 20;
+}
+
+.toolbar__group {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.toolbar__separator {
+    width: 1px;
+    height: 24px;
+    background-color: var(--color-border);
+    margin: 0 8px;
+}
+
+.toolbar__btn {
+    background: none;
+    border: 1px solid transparent;
+    color: var(--color-text-muted);
+    font-size: 1rem;
+    padding: 6px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: color 0.2s, background-color 0.2s, border-color 0.2s;
+    user-select: none;
+}
+
+.toolbar__btn:hover:not(:disabled) {
+    color: var(--color-text);
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.toolbar__btn:disabled {
+    opacity: 0.3;
+    cursor: default;
+}
+
+.toolbar__btn--play {
+    font-size: 1.25rem;
+    padding: 6px 14px;
+}
+
+.toolbar__btn--speed,
+.toolbar__btn--iw {
+    font-size: 0.8rem;
+    padding: 4px 8px;
+    border: 1px solid var(--color-border);
+}
+
+.toolbar__btn--active {
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+    background-color: rgba(233, 69, 96, 0.1);
+}
+
+.toolbar__label {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    margin-right: 4px;
+}
+
+.toolbar__progress {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+/* -----------------------------------------------------------------------
    Scroll-pause indicator
    ----------------------------------------------------------------------- */
 .scroll-pause-indicator {
     position: fixed;
-    bottom: 24px;
+    bottom: calc(var(--toolbar-height) + 16px);
     left: 50%;
     transform: translateX(-50%);
     background-color: var(--color-surface);

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -40,6 +40,45 @@
         </div>
     </main>
 
+    <!-- Playback toolbar -->
+    <div class="toolbar" x-show="view === 'playback'" x-cloak>
+        <!-- Transport controls -->
+        <div class="toolbar__group">
+            <button class="toolbar__btn" @click="skipToStart()" :disabled="playbackState === 'READY'" title="Skip to start">⏮</button>
+            <button class="toolbar__btn" @click="previousBeat()" :disabled="currentBeat === 0" title="Previous beat">⏪</button>
+            <button class="toolbar__btn toolbar__btn--play" @click="togglePlay()" title="Play/Pause"
+                    x-text="playbackState === 'PLAYING' ? '⏸' : '▶'">▶</button>
+            <button class="toolbar__btn" @click="nextBeat()" :disabled="playbackState === 'COMPLETE'" title="Next beat">⏩</button>
+            <button class="toolbar__btn" @click="skipToEnd()" :disabled="playbackState === 'COMPLETE'" title="Skip to end">⏭</button>
+        </div>
+
+        <div class="toolbar__separator"></div>
+
+        <!-- Speed presets -->
+        <div class="toolbar__group">
+            <button class="toolbar__btn toolbar__btn--speed" :class="{ 'toolbar__btn--active': speed === 0.5 }" @click="setSpeed(0.5)">0.5x</button>
+            <button class="toolbar__btn toolbar__btn--speed" :class="{ 'toolbar__btn--active': speed === 1 }" @click="setSpeed(1)">1x</button>
+            <button class="toolbar__btn toolbar__btn--speed" :class="{ 'toolbar__btn--active': speed === 1.5 }" @click="setSpeed(1.5)">1.5x</button>
+            <button class="toolbar__btn toolbar__btn--speed" :class="{ 'toolbar__btn--active': speed === 2 }" @click="setSpeed(2)">2x</button>
+        </div>
+
+        <div class="toolbar__separator"></div>
+
+        <!-- Inner workings toggle -->
+        <div class="toolbar__group">
+            <span class="toolbar__label">&#9881; Inner workings:</span>
+            <button class="toolbar__btn toolbar__btn--iw" :class="{ 'toolbar__btn--active': innerWorkingsMode === 'collapsed' }" @click="setInnerWorkingsMode('collapsed')">Collapsed</button>
+            <button class="toolbar__btn toolbar__btn--iw" :class="{ 'toolbar__btn--active': innerWorkingsMode === 'expanded' }" @click="setInnerWorkingsMode('expanded')">Expanded</button>
+        </div>
+
+        <div class="toolbar__separator"></div>
+
+        <!-- Progress indicator -->
+        <div class="toolbar__group">
+            <span class="toolbar__progress" x-text="'Beat ' + currentBeat + ' / ' + totalBeats"></span>
+        </div>
+    </div>
+
     <!-- Scroll-pause indicator -->
     <div class="scroll-pause-indicator"
          x-show="playbackState === 'SCROLL_PAUSED'"

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -10,6 +10,10 @@ function clawbackApp() {
         view: "picker", // "picker" or "playback"
         playbackState: "READY",
         showBeatNumbers: false,
+        currentBeat: 0,
+        totalBeats: 0,
+        speed: 1.0,
+        innerWorkingsMode: "expanded",
         _engine: null,
         _scroller: null,
 
@@ -36,6 +40,10 @@ function clawbackApp() {
 
             this.sessionName = name || "";
             this.view = "playback";
+            this.currentBeat = 0;
+            this.totalBeats = beats.length;
+            this.speed = 1.0;
+            this.innerWorkingsMode = "expanded";
 
             const chatArea = this.$refs.chatArea;
             chatArea.innerHTML = "";
@@ -56,12 +64,14 @@ function clawbackApp() {
                 beats: beats,
                 onBeat: (beat) => {
                     ClawbackRenderer.renderBeat(beat, chatArea);
+                    this.currentBeat = this._engine.currentIndex;
                     if (this._scroller) {
                         this._scroller.scrollToBottom();
                     }
                 },
                 onRemoveBeat: (beat) => {
                     ClawbackRenderer.removeBeat(beat, chatArea);
+                    this.currentBeat = this._engine.currentIndex;
                 },
                 onStateChange: (newState, oldState) => {
                     this.playbackState = newState;
@@ -85,5 +95,68 @@ function clawbackApp() {
                 this._engine.play();
             }
         },
+
+        /** Toggle between play and pause. */
+        togglePlay() {
+            if (!this._engine) return;
+            if (this.playbackState === "PLAYING") {
+                this._engine.pause();
+            } else {
+                this._engine.play();
+            }
+        },
+
+        /** Reset to the beginning. */
+        skipToStart() {
+            if (this._engine) {
+                this._engine.skipToStart();
+            }
+        },
+
+        /** Jump to the end. */
+        skipToEnd() {
+            if (this._engine) {
+                this._engine.skipToEnd();
+            }
+        },
+
+        /** Step forward one beat. */
+        nextBeat() {
+            if (this._engine) {
+                this._engine.next();
+            }
+        },
+
+        /** Step backward one beat. */
+        previousBeat() {
+            if (this._engine) {
+                this._engine.previous();
+            }
+        },
+
+        /** Set playback speed multiplier. */
+        setSpeed(s) {
+            this.speed = s;
+            if (this._engine) {
+                this._engine.setSpeed(s);
+            }
+        },
+
+        /** Set inner workings display mode ("expanded" or "collapsed"). */
+        setInnerWorkingsMode(mode) {
+            this.innerWorkingsMode = mode;
+            if (this._engine) {
+                this._engine.setInnerWorkingsMode(mode);
+                ClawbackRenderer.toggleAllInnerWorkings(
+                    this.$refs.chatArea,
+                    mode === "expanded"
+                );
+            }
+        },
     };
+}
+
+// CommonJS export for Node.js testing
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { clawbackApp };
 }

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -1,0 +1,333 @@
+/**
+ * Clawback — Unit tests for app.js toolbar wiring and state management.
+ *
+ * Run with: node tests/unit/js/test_app.js
+ * Or via:   make test-js
+ */
+
+const assert = require("node:assert/strict");
+const { PlaybackEngine, PlaybackState } = require("../../../app/static/js/playback.js");
+
+// ---------------------------------------------------------------------------
+// Set up globals before requiring app.js
+// ---------------------------------------------------------------------------
+
+global.PlaybackEngine = PlaybackEngine;
+global.PlaybackState = PlaybackState;
+
+let rendererCalls;
+function resetRendererCalls() {
+    rendererCalls = {
+        renderBeat: [],
+        removeBeat: [],
+        toggleAllIW: [],
+        resetGroups: 0,
+    };
+}
+resetRendererCalls();
+
+global.ClawbackRenderer = {
+    renderBeat: function (beat, container) { rendererCalls.renderBeat.push(beat); },
+    removeBeat: function (beat, container) { rendererCalls.removeBeat.push(beat); },
+    toggleAllInnerWorkings: function (container, expanded) { rendererCalls.toggleAllIW.push(expanded); },
+    resetGroups: function () { rendererCalls.resetGroups++; },
+};
+
+global.ClawbackScroller = {
+    createScroller: function () {
+        return {
+            scrollToBottom: function () {},
+            enable: function () {},
+            disable: function () {},
+            destroy: function () {},
+        };
+    },
+};
+
+const { clawbackApp } = require("../../../app/static/js/app.js");
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        passed++;
+        console.log(`  \u2713 ${name}`);
+    } catch (err) {
+        failed++;
+        console.log(`  \u2717 ${name}`);
+        console.log(`    ${err.message}`);
+    }
+}
+
+function makeBeats(n) {
+    const beats = [];
+    for (var i = 0; i < n; i++) {
+        beats.push({
+            id: i,
+            type: "user_message",
+            category: "direct",
+            content: "Beat " + i,
+            duration: 1,
+            group_id: null,
+        });
+    }
+    return beats;
+}
+
+function makeApp(numBeats) {
+    resetRendererCalls();
+    const app = clawbackApp();
+    app.$refs = { chatArea: { innerHTML: "", parentElement: {} } };
+    if (numBeats !== undefined) {
+        app.startPlayback(makeBeats(numBeats), "Test");
+    }
+    return app;
+}
+
+// ---------------------------------------------------------------------------
+// startPlayback — state initialization
+// ---------------------------------------------------------------------------
+console.log("\nstartPlayback — state initialization");
+
+test("sets totalBeats from beats array length", function () {
+    const app = makeApp(5);
+    assert.equal(app.totalBeats, 5);
+});
+
+test("sets currentBeat to 0", function () {
+    const app = makeApp(5);
+    assert.equal(app.currentBeat, 0);
+});
+
+test("resets speed to 1.0", function () {
+    const app = makeApp(5);
+    app.speed = 2.0;
+    app.startPlayback(makeBeats(3), "Test2");
+    assert.equal(app.speed, 1.0);
+});
+
+test("resets innerWorkingsMode to expanded", function () {
+    const app = makeApp(5);
+    app.innerWorkingsMode = "collapsed";
+    app.startPlayback(makeBeats(3), "Test2");
+    assert.equal(app.innerWorkingsMode, "expanded");
+});
+
+test("sets view to playback", function () {
+    const app = makeApp(5);
+    assert.equal(app.view, "playback");
+});
+
+// ---------------------------------------------------------------------------
+// Progress tracking
+// ---------------------------------------------------------------------------
+console.log("\nprogress tracking");
+
+test("currentBeat updates after next()", function () {
+    const app = makeApp(5);
+    app._engine.next();
+    assert.equal(app.currentBeat, 1);
+});
+
+test("currentBeat updates after multiple next() calls", function () {
+    const app = makeApp(5);
+    app._engine.next();
+    app._engine.next();
+    app._engine.next();
+    assert.equal(app.currentBeat, 3);
+});
+
+test("currentBeat updates after previous()", function () {
+    const app = makeApp(5);
+    app._engine.next();
+    app._engine.next();
+    assert.equal(app.currentBeat, 2);
+    app._engine.previous();
+    assert.equal(app.currentBeat, 1);
+});
+
+test("currentBeat equals totalBeats after skipToEnd()", function () {
+    const app = makeApp(5);
+    app._engine.skipToEnd();
+    assert.equal(app.currentBeat, 5);
+    assert.equal(app.currentBeat, app.totalBeats);
+});
+
+test("currentBeat is 0 after skipToStart()", function () {
+    const app = makeApp(5);
+    app._engine.next();
+    app._engine.next();
+    app._engine.skipToStart();
+    assert.equal(app.currentBeat, 0);
+});
+
+// ---------------------------------------------------------------------------
+// togglePlay
+// ---------------------------------------------------------------------------
+console.log("\ntogglePlay");
+
+test("calls play() from READY — transitions to PLAYING", function () {
+    const app = makeApp(5);
+    assert.equal(app.playbackState, "READY");
+    app.togglePlay();
+    assert.equal(app.playbackState, "PLAYING");
+});
+
+test("calls pause() from PLAYING — transitions to PAUSED", function () {
+    const app = makeApp(5);
+    app.togglePlay(); // READY → PLAYING
+    assert.equal(app.playbackState, "PLAYING");
+    app.togglePlay(); // PLAYING → PAUSED
+    assert.equal(app.playbackState, "PAUSED");
+});
+
+test("calls play() from PAUSED — transitions to PLAYING", function () {
+    const app = makeApp(5);
+    app.togglePlay(); // → PLAYING
+    app.togglePlay(); // → PAUSED
+    app.togglePlay(); // → PLAYING
+    assert.equal(app.playbackState, "PLAYING");
+});
+
+test("calls play() from SCROLL_PAUSED — transitions to PLAYING", function () {
+    const app = makeApp(5);
+    app._engine.play(); // → PLAYING
+    app._engine.scrollPause(); // → SCROLL_PAUSED
+    assert.equal(app.playbackState, "SCROLL_PAUSED");
+    app.togglePlay(); // → PLAYING
+    assert.equal(app.playbackState, "PLAYING");
+});
+
+test("is a no-op when no engine", function () {
+    const app = clawbackApp();
+    app.$refs = { chatArea: { innerHTML: "", parentElement: {} } };
+    // Should not throw
+    app.togglePlay();
+    assert.equal(app.playbackState, "READY");
+});
+
+// ---------------------------------------------------------------------------
+// Transport controls
+// ---------------------------------------------------------------------------
+console.log("\ntransport controls");
+
+test("skipToStart() resets to READY", function () {
+    const app = makeApp(5);
+    app._engine.next();
+    app._engine.next();
+    app.skipToStart();
+    assert.equal(app.playbackState, "READY");
+    assert.equal(app.currentBeat, 0);
+});
+
+test("skipToEnd() transitions to COMPLETE", function () {
+    const app = makeApp(5);
+    app.skipToEnd();
+    assert.equal(app.playbackState, "COMPLETE");
+    assert.equal(app.currentBeat, 5);
+});
+
+test("nextBeat() advances one beat", function () {
+    const app = makeApp(5);
+    app.nextBeat();
+    assert.equal(app.currentBeat, 1);
+});
+
+test("previousBeat() goes back one beat", function () {
+    const app = makeApp(5);
+    app.nextBeat();
+    app.nextBeat();
+    app.previousBeat();
+    assert.equal(app.currentBeat, 1);
+});
+
+test("transport methods are no-ops when no engine", function () {
+    const app = clawbackApp();
+    app.$refs = { chatArea: { innerHTML: "", parentElement: {} } };
+    // None should throw
+    app.skipToStart();
+    app.skipToEnd();
+    app.nextBeat();
+    app.previousBeat();
+    assert.equal(app.playbackState, "READY");
+});
+
+// ---------------------------------------------------------------------------
+// setSpeed
+// ---------------------------------------------------------------------------
+console.log("\nsetSpeed");
+
+test("updates speed property", function () {
+    const app = makeApp(5);
+    app.setSpeed(2);
+    assert.equal(app.speed, 2);
+});
+
+test("updates engine speed", function () {
+    const app = makeApp(5);
+    app.setSpeed(0.5);
+    assert.equal(app._engine.speed, 0.5);
+});
+
+test("works without engine (before startPlayback)", function () {
+    const app = clawbackApp();
+    app.$refs = { chatArea: { innerHTML: "", parentElement: {} } };
+    app.setSpeed(1.5);
+    assert.equal(app.speed, 1.5);
+});
+
+// ---------------------------------------------------------------------------
+// setInnerWorkingsMode
+// ---------------------------------------------------------------------------
+console.log("\nsetInnerWorkingsMode");
+
+test("updates innerWorkingsMode property", function () {
+    const app = makeApp(5);
+    app.setInnerWorkingsMode("collapsed");
+    assert.equal(app.innerWorkingsMode, "collapsed");
+});
+
+test("updates engine innerWorkingsMode", function () {
+    const app = makeApp(5);
+    app.setInnerWorkingsMode("collapsed");
+    assert.equal(app._engine.innerWorkingsMode, "collapsed");
+});
+
+test("calls renderer toggleAllInnerWorkings with false for collapsed", function () {
+    const app = makeApp(5);
+    resetRendererCalls();
+    app.setInnerWorkingsMode("collapsed");
+    assert.equal(rendererCalls.toggleAllIW.length, 1);
+    assert.equal(rendererCalls.toggleAllIW[0], false);
+});
+
+test("calls renderer toggleAllInnerWorkings with true for expanded", function () {
+    const app = makeApp(5);
+    app.setInnerWorkingsMode("collapsed");
+    resetRendererCalls();
+    app.setInnerWorkingsMode("expanded");
+    assert.equal(rendererCalls.toggleAllIW.length, 1);
+    assert.equal(rendererCalls.toggleAllIW[0], true);
+});
+
+test("works without engine (before startPlayback)", function () {
+    const app = clawbackApp();
+    app.$refs = { chatArea: { innerHTML: "", parentElement: {} } };
+    resetRendererCalls();
+    app.setInnerWorkingsMode("collapsed");
+    assert.equal(app.innerWorkingsMode, "collapsed");
+    // Renderer should NOT be called when no engine exists
+    assert.equal(rendererCalls.toggleAllIW.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -78,6 +78,27 @@ def test_index_script_load_order(client):
     )
 
 
+def test_index_has_toolbar(client):
+    """Index page includes the playback toolbar with all required controls."""
+    html = client.get("/").data.decode()
+    assert 'class="toolbar"' in html, "toolbar must be present"
+    # Transport controls
+    assert "skipToStart" in html, "skip-to-start button must be present"
+    assert "togglePlay" in html, "play/pause button must be present"
+    assert "skipToEnd" in html, "skip-to-end button must be present"
+    assert "nextBeat" in html, "next-beat button must be present"
+    assert "previousBeat" in html, "previous-beat button must be present"
+    # Speed presets
+    assert "setSpeed(0.5)" in html, "0.5x speed button must be present"
+    assert "setSpeed(1)" in html, "1x speed button must be present"
+    assert "setSpeed(1.5)" in html, "1.5x speed button must be present"
+    assert "setSpeed(2)" in html, "2x speed button must be present"
+    # Inner workings toggle
+    assert "setInnerWorkingsMode" in html, "inner workings toggle must be present"
+    # Progress indicator
+    assert "totalBeats" in html, "progress indicator must be present"
+
+
 def test_index_cdn_versions_are_pinned(client):
     """CDN script URLs must use pinned versions, not floating ranges."""
     html = client.get("/").data.decode()


### PR DESCRIPTION
## Summary
- Adds fixed bottom toolbar with transport controls (skip-to-start, previous, play/pause, next, skip-to-end), speed presets (0.5x/1x/1.5x/2x), inner workings toggle (Collapsed/Expanded), and progress indicator (Beat N / Total)
- All controls wired to PlaybackEngine via thin wrapper methods in `clawbackApp()`
- Active speed preset and IW mode are visually highlighted with accent color
- Scroll-pause indicator repositioned above toolbar with `calc(var(--toolbar-height) + 16px)`
- 28 unit tests for toolbar wiring + 1 Python test for toolbar HTML presence

Closes #7

## Test plan
- [x] All 190 tests pass (182 JS + 8 Python)
- [x] Lint passes
- [x] Code review completed — fixed unguarded `$refs` access in `setInnerWorkingsMode`
- [ ] Manual: verify toolbar appears during playback, hidden on picker view
- [ ] Manual: verify all transport buttons control playback correctly
- [ ] Manual: verify speed presets highlight and affect playback timing
- [ ] Manual: verify IW toggle collapses/expands all inner workings cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)