### PR TITLE
feat(picker): implement session picker landing page and file upload

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1,10 +1,69 @@
-from flask import Blueprint
+import json
+import os
+
+from flask import Blueprint, abort, jsonify
+
+from app.services.session_parser import parse_session
 
 api_bp = Blueprint("api", __name__, url_prefix="/api")
+
+
+def _sessions_dir():
+    """Return the path to the curated sessions directory."""
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "sessions",
+        "curated",
+    )
 
 
 @api_bp.route("/sessions")
 def list_sessions():
     """List available curated sessions."""
-    # Placeholder — will be implemented in issue #8
-    return {"sessions": []}
+    manifest_path = os.path.join(_sessions_dir(), "manifest.json")
+    if not os.path.exists(manifest_path):
+        return jsonify({"sessions": []})
+    with open(manifest_path) as f:
+        sessions = json.load(f)
+    if not isinstance(sessions, list):
+        return jsonify({"sessions": []})
+    return jsonify({"sessions": sessions})
+
+
+@api_bp.route("/sessions/<session_id>")
+def get_session(session_id):
+    """Return pre-parsed beats for a curated session."""
+    sessions_dir = _sessions_dir()
+    manifest_path = os.path.join(sessions_dir, "manifest.json")
+    if not os.path.exists(manifest_path):
+        abort(404)
+
+    with open(manifest_path) as f:
+        sessions = json.load(f)
+    if not isinstance(sessions, list):
+        abort(404)
+
+    session = next((s for s in sessions if s["id"] == session_id), None)
+    if not session:
+        abort(404)
+
+    # Path safety: ensure resolved path stays within sessions directory
+    file_path = os.path.realpath(os.path.join(sessions_dir, session["file"]))
+    safe_prefix = os.path.realpath(sessions_dir) + os.sep
+    if not file_path.startswith(safe_prefix):
+        abort(404)
+
+    if not os.path.exists(file_path):
+        abort(404)
+
+    with open(file_path) as f:
+        jsonl_text = f.read()
+
+    result = parse_session(jsonl_text)
+    return jsonify(
+        {
+            "title": session["title"],
+            "beats": result["beats"],
+            "errors": result["errors"],
+        }
+    )

--- a/app/services/session_parser.py
+++ b/app/services/session_parser.py
@@ -1,0 +1,299 @@
+"""Server-side JSONL-to-beats parser, mirroring the client-side parser.js.
+
+Transforms raw Claude Code session JSONL text into an ordered array
+of beat dicts for the playback engine.
+
+Pipeline: Raw JSONL -> parse lines -> filter conversation messages ->
+          order by parentUuid chain -> extract beats -> calculate durations ->
+          assign group IDs -> beat array
+"""
+
+import json
+from datetime import datetime, timezone
+
+BASE_WPM = 200
+MIN_DURATION = 1.0
+MAX_DURATION = 15.0
+CONVERSATION_TYPES = {"user", "assistant"}
+
+
+def parse_session(jsonl_text):
+    """Parse raw JSONL text into an array of beats.
+
+    Returns dict with 'beats' (list of beat dicts) and 'errors' (count of
+    malformed lines).
+    """
+    messages, errors = _parse_jsonl_lines(jsonl_text)
+    conversation = _filter_conversation_messages(messages)
+    ordered = _order_messages(conversation)
+    beats = _extract_beats(ordered)
+    _calculate_durations(beats)
+    _assign_group_ids(beats)
+    return {"beats": beats, "errors": errors}
+
+
+def _parse_jsonl_lines(text):
+    messages = []
+    errors = 0
+    for line in text.split("\n"):
+        trimmed = line.strip()
+        if not trimmed:
+            continue
+        try:
+            messages.append(json.loads(trimmed))
+        except json.JSONDecodeError:
+            errors += 1
+    return messages, errors
+
+
+def _filter_conversation_messages(messages):
+    return [m for m in messages if m.get("type") in CONVERSATION_TYPES]
+
+
+def _ts_key(msg):
+    """Parse timestamp for sorting, mirroring JS new Date() behavior."""
+    ts = msg.get("timestamp")
+    if not ts:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _order_messages(messages):
+    if not messages:
+        return []
+
+    by_uuid = {}
+    for msg in messages:
+        uuid = msg.get("uuid")
+        if uuid:
+            by_uuid[uuid] = msg
+
+    children_of = {}
+    for msg in messages:
+        parent = msg.get("parentUuid")
+        if parent:
+            children_of.setdefault(parent, []).append(msg)
+
+    roots = [
+        m
+        for m in messages
+        if not m.get("parentUuid") or m.get("parentUuid") not in by_uuid
+    ]
+
+    if not roots:
+        return sorted(messages, key=_ts_key)
+
+    roots.sort(key=_ts_key)
+
+    ordered = []
+    visited = set()
+
+    def walk(msg):
+        uuid = msg.get("uuid")
+        if not uuid or uuid in visited:
+            return
+        visited.add(uuid)
+        ordered.append(msg)
+        children = children_of.get(uuid, [])
+        children.sort(key=_ts_key)
+        for child in children:
+            walk(child)
+
+    for root in roots:
+        walk(root)
+
+    if len(ordered) < len(messages):
+        remaining = [
+            m for m in messages if not m.get("uuid") or m.get("uuid") not in visited
+        ]
+        remaining.sort(key=_ts_key)
+        ordered.extend(remaining)
+
+    return ordered
+
+
+def _extract_beats(ordered_messages):
+    beats = []
+    beat_id = 0
+
+    for msg in ordered_messages:
+        timestamp = msg.get("timestamp")
+
+        if msg["type"] == "user":
+            content = (msg.get("message") or {}).get("content")
+
+            if isinstance(content, str) and content.strip():
+                beats.append(
+                    {
+                        "id": beat_id,
+                        "type": "user_message",
+                        "category": "direct",
+                        "content": content,
+                        "metadata": {"timestamp": timestamp},
+                        "duration": 0,
+                        "group_id": None,
+                    }
+                )
+                beat_id += 1
+            elif isinstance(content, list):
+                for block in content:
+                    if block.get("type") == "tool_result":
+                        result_content = _extract_tool_result_content(block)
+                        beats.append(
+                            {
+                                "id": beat_id,
+                                "type": "tool_result",
+                                "category": "inner_working",
+                                "content": result_content,
+                                "metadata": {
+                                    "tool_use_id": block.get("tool_use_id"),
+                                    "is_error": block.get("is_error", False),
+                                    "timestamp": timestamp,
+                                },
+                                "duration": 0,
+                                "group_id": None,
+                            }
+                        )
+                        beat_id += 1
+                    elif (
+                        block.get("type") == "text"
+                        and isinstance(block.get("text"), str)
+                        and block["text"].strip()
+                    ):
+                        beats.append(
+                            {
+                                "id": beat_id,
+                                "type": "user_message",
+                                "category": "direct",
+                                "content": block["text"],
+                                "metadata": {"timestamp": timestamp},
+                                "duration": 0,
+                                "group_id": None,
+                            }
+                        )
+                        beat_id += 1
+
+        elif msg["type"] == "assistant":
+            content = (msg.get("message") or {}).get("content")
+            if not isinstance(content, list):
+                continue
+
+            for block in content:
+                block_type = block.get("type")
+
+                if block_type == "text" and isinstance(block.get("text"), str):
+                    if not block["text"].strip():
+                        continue
+                    beats.append(
+                        {
+                            "id": beat_id,
+                            "type": "assistant_message",
+                            "category": "direct",
+                            "content": block["text"],
+                            "metadata": {
+                                "model": (msg.get("message") or {}).get("model"),
+                                "timestamp": timestamp,
+                            },
+                            "duration": 0,
+                            "group_id": None,
+                        }
+                    )
+                    beat_id += 1
+
+                elif block_type == "thinking":
+                    thinking = block.get("thinking", "")
+                    if not thinking.strip():
+                        continue
+                    beats.append(
+                        {
+                            "id": beat_id,
+                            "type": "thinking",
+                            "category": "inner_working",
+                            "content": thinking,
+                            "metadata": {"timestamp": timestamp},
+                            "duration": 0,
+                            "group_id": None,
+                        }
+                    )
+                    beat_id += 1
+
+                elif block_type == "tool_use":
+                    beats.append(
+                        {
+                            "id": beat_id,
+                            "type": "tool_call",
+                            "category": "inner_working",
+                            "content": _format_tool_input(block.get("input")),
+                            "metadata": {
+                                "tool_name": block.get("name", "Unknown"),
+                                "tool_input": block.get("input", {}),
+                                "tool_use_id": block.get("id"),
+                                "timestamp": timestamp,
+                            },
+                            "duration": 0,
+                            "group_id": None,
+                        }
+                    )
+                    beat_id += 1
+
+    return beats
+
+
+def _extract_tool_result_content(block):
+    content = block.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for b in content:
+            if isinstance(b, str):
+                parts.append(b)
+            elif isinstance(b, dict) and b.get("type") == "text":
+                parts.append(b.get("text", ""))
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
+def _format_tool_input(input_val):
+    if not input_val:
+        return ""
+    if isinstance(input_val, str):
+        return input_val
+    if isinstance(input_val, dict):
+        if "command" in input_val:
+            return input_val["command"]
+        if "file_path" in input_val:
+            return input_val["file_path"]
+        if "pattern" in input_val:
+            return input_val["pattern"]
+        return json.dumps(input_val, indent=2)
+    return ""
+
+
+def _count_words(text):
+    if not text:
+        return 0
+    return len(text.split())
+
+
+def _calculate_durations(beats):
+    for beat in beats:
+        words = _count_words(beat["content"])
+        raw_seconds = (words / BASE_WPM) * 60
+        beat["duration"] = max(MIN_DURATION, min(MAX_DURATION, raw_seconds))
+
+
+def _assign_group_ids(beats):
+    group_id = 0
+    in_group = False
+    for beat in beats:
+        if beat["category"] == "inner_working":
+            if not in_group:
+                group_id += 1
+                in_group = True
+            beat["group_id"] = group_id
+        else:
+            in_group = False

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -55,6 +55,22 @@ body {
     color: var(--color-text-muted);
 }
 
+.app-header__back {
+    background: none;
+    border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+    padding: 4px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: color 0.2s, border-color 0.2s;
+}
+
+.app-header__back:hover {
+    color: var(--color-text);
+    border-color: var(--color-text-muted);
+}
+
 /* Main content area */
 .app-main {
     flex: 1;
@@ -63,14 +79,143 @@ body {
     overflow-y: auto;
 }
 
-/* Placeholder (temporary) */
-.placeholder {
+/* -----------------------------------------------------------------------
+   Session picker
+   ----------------------------------------------------------------------- */
+.picker {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 48px 0;
+}
+
+.picker__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 16px;
+    margin-bottom: 48px;
+}
+
+.picker__card {
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 20px;
+    cursor: pointer;
+    transition: border-color 0.2s, transform 0.1s;
+}
+
+.picker__card:hover {
+    border-color: var(--color-accent);
+    transform: translateY(-2px);
+}
+
+.picker__card-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--color-text);
+}
+
+.picker__card-desc {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    margin-bottom: 12px;
+    line-height: 1.5;
+}
+
+.picker__card-meta {
+    font-size: 0.8rem;
+    color: var(--color-accent);
+    font-weight: 500;
+}
+
+.picker__empty {
+    text-align: center;
+    color: var(--color-text-muted);
+    padding: 24px;
+}
+
+.picker__upload {
+    border-top: 1px solid var(--color-border);
+    padding-top: 32px;
+}
+
+.picker__upload-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 16px;
+    color: var(--color-text);
+}
+
+.picker__upload-zone {
+    border: 2px dashed var(--color-border);
+    border-radius: 12px;
+    padding: 40px;
+    text-align: center;
+    color: var(--color-text-muted);
+    transition: border-color 0.2s, background-color 0.2s;
+}
+
+.picker__upload-zone--active,
+.picker__upload-zone:hover {
+    border-color: var(--color-accent);
+    background-color: rgba(233, 69, 96, 0.05);
+}
+
+.picker__upload-zone p {
+    margin-bottom: 12px;
+}
+
+.picker__upload-zone code {
+    font-family: var(--font-mono);
+    background-color: rgba(0, 0, 0, 0.3);
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+
+.picker__upload-btn {
+    display: inline-block;
+    border: 1px solid var(--color-accent);
+    color: var(--color-accent);
+    padding: 8px 20px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: background-color 0.2s;
+}
+
+.picker__upload-btn:hover {
+    background-color: rgba(233, 69, 96, 0.1);
+}
+
+.picker__error {
+    margin-top: 12px;
+    color: var(--color-accent);
+    font-size: 0.875rem;
+}
+
+.picker__loading {
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     height: 60vh;
+    gap: 16px;
     color: var(--color-text-muted);
-    font-size: 1.125rem;
+}
+
+/* Spinner */
+.spinner {
+    width: 32px;
+    height: 32px;
+    border: 3px solid var(--color-border);
+    border-top-color: var(--color-accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
 }
 
 /* -----------------------------------------------------------------------

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -22,14 +22,62 @@
 </head>
 <body x-data="clawbackApp()">
     <header class="app-header">
+        <button class="app-header__back"
+                x-show="view === 'playback'"
+                @click="backToSessions()"
+                title="Back to sessions">&#8592; Sessions</button>
         <h1 class="app-title">Clawback</h1>
         <span class="app-subtitle" x-show="sessionName" x-text="sessionName"></span>
     </header>
 
     <main class="app-main">
-        <!-- Session picker (Issue #8) -->
-        <div class="placeholder" x-show="view === 'picker'">
-            <p>Clawback is running. Session picker coming soon.</p>
+        <!-- Session picker -->
+        <div x-show="view === 'picker'">
+            <!-- Loading sessions list -->
+            <div class="picker__loading" x-show="loadingSessions">
+                <div class="spinner"></div>
+                <p>Loading sessions&#8230;</p>
+            </div>
+
+            <!-- Loading a specific session -->
+            <div class="picker__loading" x-show="loadingSession && !loadingSessions">
+                <div class="spinner"></div>
+                <p>Loading session&#8230;</p>
+            </div>
+
+            <!-- Session picker content -->
+            <div class="picker" x-show="!loadingSessions && !loadingSession">
+                <!-- Session grid -->
+                <div class="picker__grid" x-show="sessions.length > 0">
+                    <template x-for="session in sessions" :key="session.id">
+                        <div class="picker__card" @click="loadSession(session)">
+                            <h3 class="picker__card-title" x-text="session.title"></h3>
+                            <p class="picker__card-desc" x-text="session.description"></p>
+                            <span class="picker__card-meta" x-text="session.beat_count + ' beats'"></span>
+                        </div>
+                    </template>
+                </div>
+
+                <p class="picker__empty" x-show="sessions.length === 0">
+                    No curated sessions available.
+                </p>
+
+                <!-- Upload area -->
+                <div class="picker__upload">
+                    <h3 class="picker__upload-title">Upload your own session</h3>
+                    <div class="picker__upload-zone"
+                         @dragover.prevent="$el.classList.add('picker__upload-zone--active')"
+                         @dragleave="$el.classList.remove('picker__upload-zone--active')"
+                         @drop.prevent="$el.classList.remove('picker__upload-zone--active'); handleFileDrop($event)">
+                        <p>Drop a <code>.jsonl</code> file here, or</p>
+                        <label class="picker__upload-btn">
+                            Browse files
+                            <input type="file" accept=".jsonl" @change="handleFileUpload($event)" hidden>
+                        </label>
+                    </div>
+                    <p class="picker__error" x-show="uploadError" x-text="uploadError"></p>
+                </div>
+            </div>
         </div>
 
         <!-- Playback view -->

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -2,7 +2,7 @@
  * Clawback — Main application state and Alpine.js initialization.
  *
  * Wires the parser, playback engine, renderer, and scroller together.
- * Session loading UI comes in Issue #8.
+ * Provides session picker, file upload, and playback view management.
  */
 function clawbackApp() {
     return {
@@ -14,17 +14,111 @@ function clawbackApp() {
         totalBeats: 0,
         speed: 1.0,
         innerWorkingsMode: "expanded",
+        sessions: [],
+        loadingSessions: true,
+        loadingSession: false,
+        uploadError: "",
         _engine: null,
         _scroller: null,
 
+        /** Called by Alpine.js on component initialization. */
+        init() {
+            this.fetchSessions();
+        },
+
+        /** Fetch the list of curated sessions from the API. */
+        fetchSessions() {
+            this.loadingSessions = true;
+            fetch("/api/sessions")
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    this.sessions = data.sessions || [];
+                    this.loadingSessions = false;
+                }.bind(this))
+                .catch(function () {
+                    this.sessions = [];
+                    this.loadingSessions = false;
+                }.bind(this));
+        },
+
+        /** Load a curated session by fetching its beats from the API. */
+        loadSession(session) {
+            this.loadingSession = true;
+            this.uploadError = "";
+            fetch("/api/sessions/" + session.id)
+                .then(function (r) {
+                    if (!r.ok) throw new Error("Failed to load session");
+                    return r.json();
+                })
+                .then(function (data) {
+                    this.loadingSession = false;
+                    this.startPlayback(data.beats, data.title || session.title);
+                }.bind(this))
+                .catch(function (err) {
+                    this.loadingSession = false;
+                    this.uploadError = "Failed to load session: " + err.message;
+                }.bind(this));
+        },
+
+        /** Handle file selection from the file input. */
+        handleFileUpload(event) {
+            var file = event.target.files[0];
+            if (!file) return;
+            this._readAndParseFile(file);
+        },
+
+        /** Handle file drop on the upload zone. */
+        handleFileDrop(event) {
+            var file = event.dataTransfer.files[0];
+            if (!file) return;
+            this._readAndParseFile(file);
+        },
+
+        /** Read a file via FileReader and parse it client-side. */
+        _readAndParseFile(file) {
+            this.uploadError = "";
+            var self = this;
+            var reader = new FileReader();
+            reader.onload = function (e) {
+                try {
+                    var result = ClawbackParser.parseSession(e.target.result);
+                    if (result.beats.length === 0) {
+                        self.uploadError = "No conversation beats found in file.";
+                        return;
+                    }
+                    var name = file.name.replace(/\.jsonl$/, "");
+                    self.startPlayback(result.beats, name);
+                } catch (err) {
+                    self.uploadError = "Failed to parse file: " + err.message;
+                }
+            };
+            reader.onerror = function () {
+                self.uploadError = "Failed to read file.";
+            };
+            reader.readAsText(file);
+        },
+
+        /** Return to the session picker view. */
+        backToSessions() {
+            if (this._engine) {
+                this._engine.pause();
+                this._engine = null;
+            }
+            if (this._scroller) {
+                this._scroller.destroy();
+                this._scroller = null;
+            }
+            this.view = "picker";
+            this.playbackState = "READY";
+            this.currentBeat = 0;
+            this.totalBeats = 0;
+            this.sessionName = "";
+        },
+
         /**
          * Load a parsed beat array and start the playback view.
-         * Called by the session picker (Issue #8) or via browser console:
          *
-         *   const { beats } = ClawbackParser.parseSession(jsonlText);
-         *   document.querySelector('[x-data]').__x.$data.startPlayback(beats, 'My Session');
-         *
-         * @param {Array<Object>} beats - Beat array from ClawbackParser.parseSession()
+         * @param {Array<Object>} beats - Beat array from parser
          * @param {string} [name] - Session display name
          */
         startPlayback(beats, name) {
@@ -45,44 +139,45 @@ function clawbackApp() {
             this.speed = 1.0;
             this.innerWorkingsMode = "expanded";
 
-            const chatArea = this.$refs.chatArea;
+            var chatArea = this.$refs.chatArea;
             chatArea.innerHTML = "";
             ClawbackRenderer.resetGroups();
 
-            const scrollContainer = chatArea.parentElement;
+            var scrollContainer = chatArea.parentElement;
+            var self = this;
             this._scroller = ClawbackScroller.createScroller({
                 scrollContainer: scrollContainer,
                 chatArea: chatArea,
-                onScrollPause: () => {
-                    if (this._engine) {
-                        this._engine.scrollPause();
+                onScrollPause: function () {
+                    if (self._engine) {
+                        self._engine.scrollPause();
                     }
                 },
             });
 
             this._engine = new PlaybackEngine({
                 beats: beats,
-                onBeat: (beat) => {
+                onBeat: function (beat) {
                     ClawbackRenderer.renderBeat(beat, chatArea);
-                    this.currentBeat = this._engine.currentIndex;
-                    if (this._scroller) {
-                        this._scroller.scrollToBottom();
+                    self.currentBeat = self._engine.currentIndex;
+                    if (self._scroller) {
+                        self._scroller.scrollToBottom();
                     }
                 },
-                onRemoveBeat: (beat) => {
+                onRemoveBeat: function (beat) {
                     ClawbackRenderer.removeBeat(beat, chatArea);
-                    this.currentBeat = this._engine.currentIndex;
+                    self.currentBeat = self._engine.currentIndex;
                 },
-                onStateChange: (newState, oldState) => {
-                    this.playbackState = newState;
-                    if (this._scroller) {
+                onStateChange: function (newState, oldState) {
+                    self.playbackState = newState;
+                    if (self._scroller) {
                         if (newState === "PLAYING") {
-                            this._scroller.enable();
+                            self._scroller.enable();
                             if (oldState === "SCROLL_PAUSED") {
-                                this._scroller.scrollToBottom();
+                                self._scroller.scrollToBottom();
                             }
                         } else {
-                            this._scroller.disable();
+                            self._scroller.disable();
                         }
                     }
                 },

--- a/sessions/curated/demo-session.jsonl
+++ b/sessions/curated/demo-session.jsonl
@@ -1,0 +1,15 @@
+{"type":"progress","data":{"type":"hook_progress"},"uuid":"p1","timestamp":"2026-01-01T00:00:00Z"}
+{"type":"user","message":{"content":"Hello, can you check this file?"},"uuid":"u1","parentUuid":"p1","timestamp":"2026-01-01T00:00:01Z"}
+{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"The user wants me to check a file. Let me read it."}],"model":"claude-opus-4-6"},"uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T00:00:02Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Let me take a look at that file."}],"model":"claude-opus-4-6"},"uuid":"a2","parentUuid":"a1","timestamp":"2026-01-01T00:00:03Z"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/tmp/example.py"},"id":"tool1"}],"model":"claude-opus-4-6"},"uuid":"a3","parentUuid":"a2","timestamp":"2026-01-01T00:00:04Z"}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool1","content":"def hello():\n    print('world')\n"}]},"uuid":"u2","parentUuid":"a3","timestamp":"2026-01-01T00:00:05Z"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"python /tmp/example.py"},"id":"tool2"}],"model":"claude-opus-4-6"},"uuid":"a4","parentUuid":"u2","timestamp":"2026-01-01T00:00:06Z"}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool2","content":"world"}]},"uuid":"u3","parentUuid":"a4","timestamp":"2026-01-01T00:00:07Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"The file defines a `hello()` function that prints 'world'. I ran it and confirmed it works correctly."}],"model":"claude-opus-4-6"},"uuid":"a5","parentUuid":"u3","timestamp":"2026-01-01T00:00:08Z"}
+{"type":"user","message":{"content":"Thanks! Can you also check the config?"},"uuid":"u4","parentUuid":"a5","timestamp":"2026-01-01T00:00:09Z"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/tmp/config.json"},"id":"tool3"}],"model":"claude-opus-4-6"},"uuid":"a6","parentUuid":"u4","timestamp":"2026-01-01T00:00:10Z"}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool3","content":"{\"key\": \"value\"}"}]},"uuid":"u5","parentUuid":"a6","timestamp":"2026-01-01T00:00:11Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"The config looks good — it has a single key-value pair."}],"model":"claude-opus-4-6"},"uuid":"a7","parentUuid":"u5","timestamp":"2026-01-01T00:00:12Z"}
+{"type":"system","subtype":"info","content":"context compacted","uuid":"s1","timestamp":"2026-01-01T00:00:13Z"}
+{"type":"file-history-snapshot","messageId":"x","snapshot":{"timestamp":"2026-01-01T00:00:14Z"}}

--- a/sessions/curated/manifest.json
+++ b/sessions/curated/manifest.json
@@ -1,0 +1,9 @@
+[
+    {
+        "id": "demo-session",
+        "title": "Demo: File Review",
+        "description": "A sample conversation where Claude reads and runs a Python file, then reviews a config.",
+        "file": "demo-session.jsonl",
+        "beat_count": 12
+    }
+]

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -327,6 +327,34 @@ test("works without engine (before startPlayback)", function () {
 });
 
 // ---------------------------------------------------------------------------
+// backToSessions
+// ---------------------------------------------------------------------------
+console.log("\nbackToSessions");
+
+test("resets to picker view and cleans up engine/scroller", function () {
+    const app = makeApp(5);
+    app._engine.next();
+    assert.equal(app.currentBeat, 1);
+
+    app.backToSessions();
+    assert.equal(app.view, "picker");
+    assert.equal(app.playbackState, "READY");
+    assert.equal(app.currentBeat, 0);
+    assert.equal(app.totalBeats, 0);
+    assert.equal(app.sessionName, "");
+    assert.equal(app._engine, null);
+    assert.equal(app._scroller, null);
+});
+
+test("is safe when no engine exists", function () {
+    const app = clawbackApp();
+    app.$refs = { chatArea: { innerHTML: "", parentElement: {} } };
+    // Should not throw
+    app.backToSessions();
+    assert.equal(app.view, "picker");
+});
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,5 +1,52 @@
-def test_sessions_endpoint_returns_200(client):
-    """Sessions endpoint returns 200 with empty list."""
+def test_sessions_list_returns_200(client):
+    """Sessions endpoint returns 200 with session list."""
     response = client.get("/api/sessions")
     assert response.status_code == 200
-    assert response.json == {"sessions": []}
+    sessions = response.json["sessions"]
+    assert isinstance(sessions, list)
+
+
+def test_sessions_list_includes_required_fields(client):
+    """Each session in list has id, title, description, beat_count."""
+    response = client.get("/api/sessions")
+    for session in response.json["sessions"]:
+        assert "id" in session
+        assert "title" in session
+        assert "description" in session
+        assert "beat_count" in session
+
+
+def test_get_session_returns_beats(client):
+    """Getting a specific session returns beats array."""
+    response = client.get("/api/sessions")
+    sessions = response.json["sessions"]
+    assert len(sessions) > 0
+
+    session_id = sessions[0]["id"]
+    response = client.get(f"/api/sessions/{session_id}")
+    assert response.status_code == 200
+    data = response.json
+    assert "beats" in data
+    assert "title" in data
+    assert isinstance(data["beats"], list)
+    assert len(data["beats"]) > 0
+
+
+def test_get_session_beats_have_correct_structure(client):
+    """Beats returned by the API have the expected structure."""
+    response = client.get("/api/sessions")
+    session_id = response.json["sessions"][0]["id"]
+
+    response = client.get(f"/api/sessions/{session_id}")
+    beat = response.json["beats"][0]
+    assert "id" in beat
+    assert "type" in beat
+    assert "category" in beat
+    assert "content" in beat
+    assert "duration" in beat
+
+
+def test_get_session_404_for_unknown_id(client):
+    """Getting a nonexistent session returns 404."""
+    response = client.get("/api/sessions/nonexistent-id-xyz")
+    assert response.status_code == 404

--- a/tests/unit/test_session_parser.py
+++ b/tests/unit/test_session_parser.py
@@ -1,0 +1,136 @@
+"""Unit tests for server-side session parser."""
+
+import os
+
+from app.services.session_parser import parse_session
+
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "js", "fixtures", "test-session.jsonl"
+)
+
+
+def _load_fixture():
+    with open(FIXTURE_PATH) as f:
+        return f.read()
+
+
+def test_parse_session_returns_beats_and_errors():
+    result = parse_session(_load_fixture())
+    assert "beats" in result
+    assert "errors" in result
+    assert isinstance(result["beats"], list)
+    assert isinstance(result["errors"], int)
+
+
+def test_parse_session_correct_beat_count():
+    """Fixture produces 12 beats: 2 user, 3 assistant, 1 thinking, 3 tool_call, 3 tool_result."""
+    result = parse_session(_load_fixture())
+    assert len(result["beats"]) == 12
+
+
+def test_parse_session_no_errors_on_valid_input():
+    result = parse_session(_load_fixture())
+    assert result["errors"] == 0
+
+
+def test_beat_structure():
+    """Each beat has all required fields."""
+    result = parse_session(_load_fixture())
+    beat = result["beats"][0]
+    assert "id" in beat
+    assert "type" in beat
+    assert "category" in beat
+    assert "content" in beat
+    assert "metadata" in beat
+    assert "duration" in beat
+    assert "group_id" in beat
+
+
+def test_beat_types():
+    """All expected beat types are present."""
+    result = parse_session(_load_fixture())
+    types = {b["type"] for b in result["beats"]}
+    assert "user_message" in types
+    assert "assistant_message" in types
+    assert "thinking" in types
+    assert "tool_call" in types
+    assert "tool_result" in types
+
+
+def test_beat_categories():
+    """Direct and inner_working categories are correctly assigned."""
+    result = parse_session(_load_fixture())
+    for beat in result["beats"]:
+        if beat["type"] in ("user_message", "assistant_message"):
+            assert beat["category"] == "direct"
+        else:
+            assert beat["category"] == "inner_working"
+
+
+def test_durations_are_clamped():
+    """All durations fall within [MIN_DURATION, MAX_DURATION]."""
+    result = parse_session(_load_fixture())
+    for beat in result["beats"]:
+        assert 1.0 <= beat["duration"] <= 15.0
+
+
+def test_group_ids_assigned_to_inner_workings():
+    """Inner working beats get group_id; direct beats get None."""
+    result = parse_session(_load_fixture())
+    for beat in result["beats"]:
+        if beat["category"] == "inner_working":
+            assert beat["group_id"] is not None
+        else:
+            assert beat["group_id"] is None
+
+
+def test_consecutive_inner_workings_share_group_id():
+    """Consecutive inner working beats share the same group_id."""
+    result = parse_session(_load_fixture())
+    beats = result["beats"]
+    # Find first group of consecutive inner_working beats
+    groups = {}
+    for beat in beats:
+        if beat["group_id"] is not None:
+            groups.setdefault(beat["group_id"], []).append(beat)
+    # At least one group should exist with multiple items
+    multi = [g for g in groups.values() if len(g) > 1]
+    assert len(multi) > 0, "Expected at least one multi-item inner workings group"
+
+
+def test_empty_input():
+    result = parse_session("")
+    assert result["beats"] == []
+    assert result["errors"] == 0
+
+
+def test_malformed_jsonl():
+    result = parse_session("not json\nalso not json\n")
+    assert result["beats"] == []
+    assert result["errors"] == 2
+
+
+def test_filters_non_conversation_messages():
+    """System and progress messages are filtered out."""
+    result = parse_session(_load_fixture())
+    for beat in result["beats"]:
+        assert beat["type"] not in ("system", "progress", "file-history-snapshot")
+
+
+def test_tool_call_content_shows_relevant_field():
+    """Tool call content shows command/file_path, not full JSON."""
+    result = parse_session(_load_fixture())
+    tool_calls = [b for b in result["beats"] if b["type"] == "tool_call"]
+    assert len(tool_calls) >= 2
+    # First tool_call is Read with file_path
+    assert "/tmp/example.py" in tool_calls[0]["content"]
+    # Second is Bash with command
+    assert "python" in tool_calls[1]["content"]
+
+
+def test_tool_call_metadata_includes_tool_name():
+    """Tool call metadata includes the tool name."""
+    result = parse_session(_load_fixture())
+    tool_calls = [b for b in result["beats"] if b["type"] == "tool_call"]
+    assert tool_calls[0]["metadata"]["tool_name"] == "Read"
+    assert tool_calls[1]["metadata"]["tool_name"] == "Bash"

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -78,6 +78,18 @@ def test_index_script_load_order(client):
     )
 
 
+def test_index_has_session_picker(client):
+    """Index page includes the session picker UI with upload."""
+    html = client.get("/").data.decode()
+    assert "picker" in html, "session picker must be present"
+    assert "loadSession" in html, "session loading must be present"
+    assert 'type="file"' in html, "file upload input must be present"
+    assert ".jsonl" in html, "file upload must accept .jsonl files"
+    assert "backToSessions" in html, "back button must be present"
+    assert "handleFileUpload" in html, "file upload handler must be present"
+    assert "handleFileDrop" in html, "drag-and-drop handler must be present"
+
+
 def test_index_has_toolbar(client):
     """Index page includes the playback toolbar with all required controls."""
     html = client.get("/").data.decode()


### PR DESCRIPTION
## Summary
- Adds session picker landing page with card grid for curated sessions and drag-and-drop file upload
- Implements `GET /api/sessions` (manifest) and `GET /api/sessions/<id>` (parsed beats) endpoints
- Adds server-side Python parser (`session_parser.py`) mirroring client-side `parser.js` with proper datetime sorting
- File upload uses FileReader API — no data sent to server
- "Back to sessions" button returns to picker with clean engine teardown
- Path traversal protection on session file serving, manifest structure validation
- Includes demo curated session for testing

Closes #8

## Test plan
- [x] All 212 tests pass (185 JS + 27 Python)
- [x] Lint passes
- [x] Code review completed — fixed path traversal prefix, manifest validation, timestamp sorting, teardown side effects
- [ ] Manual: verify session picker loads and displays demo session card
- [ ] Manual: verify clicking card loads session into playback
- [ ] Manual: verify file upload (.jsonl) transitions to playback
- [ ] Manual: verify drag-and-drop works on upload zone
- [ ] Manual: verify "Back to sessions" returns to picker cleanly
- [ ] Manual: verify error state for invalid file upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)