### PR TITLE
feat(polish): add box shadows and keyboard shortcuts (#9)

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -242,6 +242,7 @@ body {
     overflow-wrap: break-word;
     animation: fadeSlideUp 0.3s ease-out;
     line-height: 1.6;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 /* User bubble — right-aligned, distinct background */
@@ -403,6 +404,7 @@ body {
     border-radius: 12px;
     animation: fadeSlideUp 0.3s ease-out;
     overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 .iw-card__header {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -20,7 +20,7 @@
          needs clawbackApp() to be defined before it initializes -->
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"></script>
 </head>
-<body x-data="clawbackApp()">
+<body x-data="clawbackApp()" @keydown.window="handleKeydown($event)">
     <header class="app-header">
         <button class="app-header__back"
                 x-show="view === 'playback'"

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -26,6 +26,28 @@ function clawbackApp() {
             this.fetchSessions();
         },
 
+        /** Handle keyboard shortcuts (bound via @keydown.window on body). */
+        handleKeydown(event) {
+            if (this.view !== "playback") return;
+            if (event.target.tagName === "INPUT" || event.target.tagName === "TEXTAREA" || event.target.tagName === "SELECT") return;
+            if (event.target.isContentEditable) return;
+
+            switch (event.code) {
+                case "Space":
+                    event.preventDefault();
+                    this.togglePlay();
+                    break;
+                case "ArrowLeft":
+                    event.preventDefault();
+                    this.previousBeat();
+                    break;
+                case "ArrowRight":
+                    event.preventDefault();
+                    this.nextBeat();
+                    break;
+            }
+        },
+
         /** Fetch the list of curated sessions from the API. */
         fetchSessions() {
             this.loadingSessions = true;

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -355,6 +355,106 @@ test("is safe when no engine exists", function () {
 });
 
 // ---------------------------------------------------------------------------
+// handleKeydown — keyboard shortcuts
+// ---------------------------------------------------------------------------
+console.log("\nhandleKeydown — keyboard shortcuts");
+
+function makeKeyEvent(code, opts) {
+    var prevented = false;
+    return Object.assign({
+        code: code,
+        target: { tagName: "BODY" },
+        preventDefault: function () { prevented = true; },
+        get defaultPrevented() { return prevented; },
+    }, opts || {});
+}
+
+test("Space toggles play in playback view", function () {
+    const app = makeApp(5);
+    assert.equal(app.playbackState, "READY");
+    var evt = makeKeyEvent("Space");
+    app.handleKeydown(evt);
+    assert.equal(app.playbackState, "PLAYING");
+    assert.equal(evt.defaultPrevented, true);
+});
+
+test("Space pauses when already playing", function () {
+    const app = makeApp(5);
+    app._engine.play();
+    assert.equal(app.playbackState, "PLAYING");
+    app.handleKeydown(makeKeyEvent("Space"));
+    assert.equal(app.playbackState, "PAUSED");
+});
+
+test("ArrowRight advances one beat", function () {
+    const app = makeApp(5);
+    var evt = makeKeyEvent("ArrowRight");
+    app.handleKeydown(evt);
+    assert.equal(app.currentBeat, 1);
+    assert.equal(evt.defaultPrevented, true);
+});
+
+test("ArrowLeft goes back one beat", function () {
+    const app = makeApp(5);
+    app._engine.next();
+    app._engine.next();
+    assert.equal(app.currentBeat, 2);
+    var evt = makeKeyEvent("ArrowLeft");
+    app.handleKeydown(evt);
+    assert.equal(app.currentBeat, 1);
+    assert.equal(evt.defaultPrevented, true);
+});
+
+test("keys are ignored in picker view", function () {
+    const app = clawbackApp();
+    app.$refs = { chatArea: { innerHTML: "", parentElement: {} } };
+    assert.equal(app.view, "picker");
+    var evt = makeKeyEvent("Space");
+    app.handleKeydown(evt);
+    assert.equal(app.playbackState, "READY");
+    assert.equal(evt.defaultPrevented, false);
+});
+
+test("keys are ignored when target is INPUT", function () {
+    const app = makeApp(5);
+    var evt = makeKeyEvent("Space", { target: { tagName: "INPUT" } });
+    app.handleKeydown(evt);
+    assert.equal(app.playbackState, "READY");
+    assert.equal(evt.defaultPrevented, false);
+});
+
+test("keys are ignored when target is TEXTAREA", function () {
+    const app = makeApp(5);
+    var evt = makeKeyEvent("Space", { target: { tagName: "TEXTAREA" } });
+    app.handleKeydown(evt);
+    assert.equal(app.playbackState, "READY");
+    assert.equal(evt.defaultPrevented, false);
+});
+
+test("keys are ignored when target is SELECT", function () {
+    const app = makeApp(5);
+    var evt = makeKeyEvent("Space", { target: { tagName: "SELECT" } });
+    app.handleKeydown(evt);
+    assert.equal(app.playbackState, "READY");
+    assert.equal(evt.defaultPrevented, false);
+});
+
+test("keys are ignored when target is contentEditable", function () {
+    const app = makeApp(5);
+    var evt = makeKeyEvent("Space", { target: { tagName: "DIV", isContentEditable: true } });
+    app.handleKeydown(evt);
+    assert.equal(app.playbackState, "READY");
+    assert.equal(evt.defaultPrevented, false);
+});
+
+test("unhandled keys are ignored (no error)", function () {
+    const app = makeApp(5);
+    var evt = makeKeyEvent("KeyA");
+    app.handleKeydown(evt);
+    assert.equal(evt.defaultPrevented, false);
+});
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -90,6 +90,13 @@ def test_index_has_session_picker(client):
     assert "handleFileDrop" in html, "drag-and-drop handler must be present"
 
 
+def test_index_has_keyboard_shortcut_binding(client):
+    """Body element binds keyboard shortcuts via Alpine.js."""
+    html = client.get("/").data.decode()
+    assert "handleKeydown" in html, "keyboard shortcut handler must be bound"
+    assert "@keydown.window" in html, "keyboard events must use @keydown.window"
+
+
 def test_index_has_toolbar(client):
     """Index page includes the playback toolbar with all required controls."""
     html = client.get("/").data.decode()


### PR DESCRIPTION
## Summary

- Add `box-shadow` to chat bubbles (`.bubble`) and inner workings cards (`.iw-card`) for visual depth
- Implement keyboard shortcuts: **Space** (play/pause), **Left arrow** (previous beat), **Right arrow** (next beat)
- Guard shortcuts against form controls (INPUT, TEXTAREA, SELECT, contentEditable)

Closes #9

## Test plan

- [x] All 223 tests pass (195 JS + 28 Python)
- [ ] Verify box shadows render on chat bubbles and IW cards
- [ ] Verify Space toggles play/pause during playback
- [ ] Verify Left/Right arrows step through beats
- [ ] Verify shortcuts are inactive on the session picker view
- [ ] Cross-browser check: Chrome, Firefox, Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)