### PR TITLE
refactor: simplify Phase 3 code

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 from flask import Blueprint, abort, jsonify
 
@@ -7,40 +8,36 @@ from app.services.session_parser import parse_session
 
 api_bp = Blueprint("api", __name__, url_prefix="/api")
 
+_SESSIONS_DIR = Path(__file__).resolve().parent.parent.parent / "sessions" / "curated"
 
-def _sessions_dir():
-    """Return the path to the curated sessions directory."""
-    return os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-        "sessions",
-        "curated",
-    )
+
+def _load_manifest():
+    """Load and validate the curated sessions manifest.
+
+    Returns the session list, or None if the manifest is missing or invalid.
+    """
+    manifest_path = _SESSIONS_DIR / "manifest.json"
+    if not manifest_path.exists():
+        return None
+    with open(manifest_path) as f:
+        sessions = json.load(f)
+    if not isinstance(sessions, list):
+        return None
+    return sessions
 
 
 @api_bp.route("/sessions")
 def list_sessions():
     """List available curated sessions."""
-    manifest_path = os.path.join(_sessions_dir(), "manifest.json")
-    if not os.path.exists(manifest_path):
-        return jsonify({"sessions": []})
-    with open(manifest_path) as f:
-        sessions = json.load(f)
-    if not isinstance(sessions, list):
-        return jsonify({"sessions": []})
-    return jsonify({"sessions": sessions})
+    sessions = _load_manifest()
+    return jsonify({"sessions": sessions or []})
 
 
 @api_bp.route("/sessions/<session_id>")
 def get_session(session_id):
     """Return pre-parsed beats for a curated session."""
-    sessions_dir = _sessions_dir()
-    manifest_path = os.path.join(sessions_dir, "manifest.json")
-    if not os.path.exists(manifest_path):
-        abort(404)
-
-    with open(manifest_path) as f:
-        sessions = json.load(f)
-    if not isinstance(sessions, list):
+    sessions = _load_manifest()
+    if sessions is None:
         abort(404)
 
     session = next((s for s in sessions if s["id"] == session_id), None)
@@ -48,16 +45,14 @@ def get_session(session_id):
         abort(404)
 
     # Path safety: ensure resolved path stays within sessions directory
-    file_path = os.path.realpath(os.path.join(sessions_dir, session["file"]))
-    safe_prefix = os.path.realpath(sessions_dir) + os.sep
-    if not file_path.startswith(safe_prefix):
+    file_path = (_SESSIONS_DIR / session["file"]).resolve()
+    if not str(file_path).startswith(str(_SESSIONS_DIR.resolve()) + os.sep):
         abort(404)
 
-    if not os.path.exists(file_path):
+    if not file_path.exists():
         abort(404)
 
-    with open(file_path) as f:
-        jsonl_text = f.read()
+    jsonl_text = file_path.read_text()
 
     result = parse_session(jsonl_text)
     return jsonify(

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -287,6 +287,22 @@ body {
 }
 
 /* -----------------------------------------------------------------------
+   Shared code block styles (assistant bubbles + inner workings)
+   ----------------------------------------------------------------------- */
+.bubble--assistant pre,
+.iw-item__content pre {
+    border-radius: 6px;
+    overflow-x: auto;
+}
+
+.bubble--assistant pre code,
+.iw-item__content pre code {
+    display: block;
+    background-color: rgba(0, 0, 0, 0.3);
+    line-height: 1.5;
+}
+
+/* -----------------------------------------------------------------------
    Markdown content within assistant bubbles
    ----------------------------------------------------------------------- */
 .bubble--assistant h1,
@@ -338,16 +354,11 @@ body {
 
 .bubble--assistant pre {
     margin: 0.5em 0;
-    border-radius: 6px;
-    overflow-x: auto;
 }
 
 .bubble--assistant pre code {
-    display: block;
     padding: 12px;
-    background-color: rgba(0, 0, 0, 0.3);
     font-size: 0.85em;
-    line-height: 1.5;
 }
 
 .bubble--assistant table {
@@ -490,16 +501,11 @@ body {
 
 .iw-item__content pre {
     margin: 0;
-    border-radius: 6px;
-    overflow-x: auto;
 }
 
 .iw-item__content pre code {
-    display: block;
     padding: 8px 12px;
-    background-color: rgba(0, 0, 0, 0.3);
     font-size: 0.9em;
-    line-height: 1.5;
 }
 
 .iw-item__content--scrollable {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -29,7 +29,9 @@ function clawbackApp() {
         /** Handle keyboard shortcuts (bound via @keydown.window on body). */
         handleKeydown(event) {
             if (this.view !== "playback") return;
-            if (event.target.tagName === "INPUT" || event.target.tagName === "TEXTAREA" || event.target.tagName === "SELECT") return;
+
+            var tag = event.target.tagName;
+            if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
             if (event.target.isContentEditable) return;
 
             switch (event.code) {
@@ -120,16 +122,21 @@ function clawbackApp() {
             reader.readAsText(file);
         },
 
-        /** Return to the session picker view. */
-        backToSessions() {
+        /** Tear down the current engine and scroller. */
+        _teardown(stopMethod) {
             if (this._engine) {
-                this._engine.pause();
+                this._engine[stopMethod]();
                 this._engine = null;
             }
             if (this._scroller) {
                 this._scroller.destroy();
                 this._scroller = null;
             }
+        },
+
+        /** Return to the session picker view. */
+        backToSessions() {
+            this._teardown("pause");
             this.view = "picker";
             this.playbackState = "READY";
             this.currentBeat = 0;
@@ -144,15 +151,7 @@ function clawbackApp() {
          * @param {string} [name] - Session display name
          */
         startPlayback(beats, name) {
-            // Tear down previous engine and scroller if re-entering
-            if (this._engine) {
-                this._engine.skipToStart();
-                this._engine = null;
-            }
-            if (this._scroller) {
-                this._scroller.destroy();
-                this._scroller = null;
-            }
+            this._teardown("skipToStart");
 
             this.sessionName = name || "";
             this.view = "playback";

--- a/app/static/js/playback.js
+++ b/app/static/js/playback.js
@@ -258,8 +258,7 @@ class PlaybackEngine {
         }, waitMs);
     }
 
-    _getBeatDurationMs(beat, speed) {
-        speed = speed !== undefined ? speed : this.speed;
+    _getBeatDurationMs(beat, speed = this.speed) {
         if (this.innerWorkingsMode === "collapsed" && beat.category === "inner_working") {
             return 0;
         }

--- a/app/static/js/renderer.js
+++ b/app/static/js/renderer.js
@@ -171,6 +171,15 @@ function _createGroupCard(groupId, container) {
     return group;
 }
 
+function _appendHighlightedCode(container, text) {
+    const pre = document.createElement("pre");
+    const code = document.createElement("code");
+    code.textContent = text;
+    pre.appendChild(code);
+    container.appendChild(pre);
+    hljs.highlightElement(code);
+}
+
 function _addItemToGroup(beat, group) {
     const item = document.createElement("div");
     item.classList.add("iw-item");
@@ -196,12 +205,7 @@ function _addItemToGroup(beat, group) {
         icon.textContent = "\uD83D\uDD27";
         const toolName = (beat.metadata && beat.metadata.tool_name) || "Unknown";
         label.textContent = "Tool Call: " + toolName;
-        const tcPre = document.createElement("pre");
-        const tcCode = document.createElement("code");
-        tcCode.textContent = beat.content;
-        tcPre.appendChild(tcCode);
-        content.appendChild(tcPre);
-        hljs.highlightElement(tcCode);
+        _appendHighlightedCode(content, beat.content);
     } else if (beat.type === "tool_result") {
         icon.textContent = "\uD83D\uDCCB";
         label.textContent = "Tool Result";
@@ -210,12 +214,7 @@ function _addItemToGroup(beat, group) {
             item.classList.add("iw-item--error");
         }
         content.classList.add("iw-item__content--scrollable");
-        const trPre = document.createElement("pre");
-        const trCode = document.createElement("code");
-        trCode.textContent = beat.content;
-        trPre.appendChild(trCode);
-        content.appendChild(trPre);
-        hljs.highlightElement(trCode);
+        _appendHighlightedCode(content, beat.content);
     }
 
     itemHeader.appendChild(icon);
@@ -238,19 +237,20 @@ function _addItemToGroup(beat, group) {
     }
 }
 
+function _pluralize(count, singular, plural) {
+    return count + " " + (count !== 1 ? plural : singular);
+}
+
 function _updateSummary(group) {
     const parts = [];
     if (group.counts.thinking > 0) {
-        const n = group.counts.thinking;
-        parts.push(n + " thought" + (n !== 1 ? "s" : ""));
+        parts.push(_pluralize(group.counts.thinking, "thought", "thoughts"));
     }
     if (group.counts.tool_call > 0) {
-        const n = group.counts.tool_call;
-        parts.push(n + " tool call" + (n !== 1 ? "s" : ""));
+        parts.push(_pluralize(group.counts.tool_call, "tool call", "tool calls"));
     }
     if (group.counts.tool_result > 0) {
-        const n = group.counts.tool_result;
-        parts.push(n + " result" + (n !== 1 ? "s" : ""));
+        parts.push(_pluralize(group.counts.tool_result, "result", "results"));
     }
     group.summary.textContent = "Inner workings: " + parts.join(", ");
 }


### PR DESCRIPTION
## Summary
- Extract `_appendHighlightedCode` and `_pluralize` helpers in renderer.js (eliminated 12 lines of duplication)
- Extract `_teardown(stopMethod)` in app.js to consolidate engine/scroller cleanup
- Extract `_load_manifest()` and use `_SESSIONS_DIR` pathlib constant in api.py
- Use ES6 default parameter in playback.js `_getBeatDurationMs`
- Consolidate shared `pre code` CSS styles between assistant bubbles and IW cards

## Test plan
- [x] All 195 JS unit tests pass
- [x] All 28 Python unit tests pass
- [x] All 19 Playwright integration tests pass
- [x] Linter passes (`ruff check .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)