### PR TITLE
feat(auth): add optional CLAWBACK_SECRET access gating

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 
 from app.config import Config
+from app.middleware.auth import check_secret
 
 
 def create_app(config=None):
@@ -10,6 +11,8 @@ def create_app(config=None):
 
     if config:
         app.config.update(config)
+
+    app.before_request(check_secret)
 
     from app.routes import register_blueprints
 

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -1,0 +1,41 @@
+"""Optional shared-secret authentication middleware.
+
+When the CLAWBACK_SECRET config value is set, all routes except /health
+require a matching secret via query parameter or header. When unset,
+all routes are accessible without authentication.
+"""
+
+import hmac
+
+from flask import current_app, request
+
+
+def check_secret():
+    """Flask before_request hook that enforces shared-secret auth.
+
+    Returns None (allow) or a 401 tuple (deny).
+    """
+    secret = current_app.config.get("CLAWBACK_SECRET")
+    if not secret:
+        return None
+
+    if request.path == "/health":
+        return None
+
+    provided = request.args.get("secret") or request.headers.get("X-Clawback-Secret")
+    if provided and hmac.compare_digest(provided, secret):
+        return None
+
+    return _unauthorized_response()
+
+
+def _unauthorized_response():
+    """Return a minimal 401 HTML error page."""
+    html = (
+        "<!doctype html>"
+        "<html><head><title>401 Unauthorized</title></head>"
+        "<body><h1>401 Unauthorized</h1>"
+        "<p>A valid secret is required to access this application.</p>"
+        "</body></html>"
+    )
+    return html, 401

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,122 @@
+"""Unit tests for optional shared-secret authentication middleware."""
+
+import pytest
+
+from app import create_app
+
+
+@pytest.fixture()
+def secret_app():
+    """Flask test app with CLAWBACK_SECRET configured."""
+    app = create_app({"TESTING": True, "CLAWBACK_SECRET": "test-secret-42"})
+    return app
+
+
+@pytest.fixture()
+def open_app():
+    """Flask test app without CLAWBACK_SECRET (open access)."""
+    app = create_app({"TESTING": True, "CLAWBACK_SECRET": None})
+    return app
+
+
+# -- No secret configured: all routes accessible --
+
+
+def test_open_index(open_app):
+    """Index is accessible without secret when CLAWBACK_SECRET is unset."""
+    with open_app.test_client() as c:
+        r = c.get("/")
+        assert r.status_code == 200
+
+
+def test_open_api(open_app):
+    """API is accessible without secret when CLAWBACK_SECRET is unset."""
+    with open_app.test_client() as c:
+        r = c.get("/api/sessions")
+        assert r.status_code == 200
+
+
+def test_open_health(open_app):
+    """Health endpoint is accessible without secret when CLAWBACK_SECRET is unset."""
+    with open_app.test_client() as c:
+        r = c.get("/health")
+        assert r.status_code == 200
+
+
+# -- Secret configured: unauthenticated requests blocked --
+
+
+def test_no_secret_returns_401(secret_app):
+    """Requests without a secret return 401."""
+    with secret_app.test_client() as c:
+        r = c.get("/")
+        assert r.status_code == 401
+
+
+def test_wrong_secret_query_returns_401(secret_app):
+    """Requests with wrong secret in query param return 401."""
+    with secret_app.test_client() as c:
+        r = c.get("/?secret=wrong-secret")
+        assert r.status_code == 401
+
+
+def test_wrong_secret_header_returns_401(secret_app):
+    """Requests with wrong secret in header return 401."""
+    with secret_app.test_client() as c:
+        r = c.get("/", headers={"X-Clawback-Secret": "wrong-secret"})
+        assert r.status_code == 401
+
+
+def test_401_body_contains_unauthorized(secret_app):
+    """401 response contains a meaningful error message."""
+    with secret_app.test_client() as c:
+        r = c.get("/")
+        assert b"401 Unauthorized" in r.data
+
+
+# -- Secret configured: authenticated requests allowed --
+
+
+def test_correct_secret_query_param(secret_app):
+    """Correct secret via query parameter grants access."""
+    with secret_app.test_client() as c:
+        r = c.get("/?secret=test-secret-42")
+        assert r.status_code == 200
+
+
+def test_correct_secret_header(secret_app):
+    """Correct secret via X-Clawback-Secret header grants access."""
+    with secret_app.test_client() as c:
+        r = c.get("/", headers={"X-Clawback-Secret": "test-secret-42"})
+        assert r.status_code == 200
+
+
+def test_correct_secret_api_access(secret_app):
+    """API routes are accessible with correct secret."""
+    with secret_app.test_client() as c:
+        r = c.get("/api/sessions?secret=test-secret-42")
+        assert r.status_code == 200
+
+
+def test_correct_secret_static_access(secret_app):
+    """Static files are accessible with correct secret."""
+    with secret_app.test_client() as c:
+        r = c.get("/static/css/style.css?secret=test-secret-42")
+        assert r.status_code == 200
+
+
+# -- Health endpoint always accessible --
+
+
+def test_health_no_secret_required(secret_app):
+    """Health endpoint is accessible without secret even when CLAWBACK_SECRET is set."""
+    with secret_app.test_client() as c:
+        r = c.get("/health")
+        assert r.status_code == 200
+
+
+def test_health_returns_ok(secret_app):
+    """Health endpoint returns correct JSON."""
+    with secret_app.test_client() as c:
+        r = c.get("/health")
+        assert r.json == {"status": "ok"}


### PR DESCRIPTION
## Summary
- Add `before_request` middleware in `app/middleware/auth.py` that enforces shared-secret auth when `CLAWBACK_SECRET` env var is set
- Secret accepted via `?secret=` query param or `X-Clawback-Secret` header
- `/health` endpoint always accessible (no auth required)
- Uses `hmac.compare_digest` for timing-safe secret comparison
- When `CLAWBACK_SECRET` is unset, all routes remain open

## Test plan
- [x] 13 new auth unit tests covering: open access, blocked access, authenticated access, health bypass
- [x] All 41 Python unit tests pass
- [x] All 19 Playwright integration tests pass
- [x] Linter passes

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)