### PR TITLE
ci: publish Docker image to ghcr.io on main merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,prefix=,format=short
+            type=sha,format=short
 
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary

- Build and health-check the Docker image on every push and PR
- On merges to `main`, push to `ghcr.io/bakeb7j0/clawback` with `latest` and short-SHA tags
- Uses `docker/build-push-action` v6 with buildx, `metadata-action` for tagging, `login-action` for ghcr.io auth via `GITHUB_TOKEN`

## Test plan

- [ ] PR CI run builds image and passes health check (no push)
- [ ] After merge, CI pushes image to ghcr.io with `latest` and `sha-<hash>` tags
- [ ] `docker pull ghcr.io/bakeb7j0/clawback:latest` works after merge

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)