### PR TITLE
docs: add container registry quick start to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,31 @@ A web-based session replay tool for Claude Code. Clawback transforms Claude Code
 
 ## Quick Start
 
-### Docker (recommended)
+### Run from GitHub Container Registry
+
+Create a `docker-compose.yml`:
+
+```yaml
+services:
+  clawback:
+    image: ghcr.io/bakeb7j0/clawback:latest
+    ports:
+      - "8080:8080"
+    # environment:
+    #   CLAWBACK_SECRET: change-me
+```
 
 ```bash
+docker compose up
+```
+
+Open [http://localhost:8080](http://localhost:8080).
+
+### Build from source
+
+```bash
+git clone https://github.com/bakeb7j0/clawback.git
+cd clawback
 docker compose up
 ```
 


### PR DESCRIPTION
## Summary

- Add "Run from GitHub Container Registry" section with a minimal standalone `docker-compose.yml`
- Rename existing Docker section to "Build from source" for clarity
- `CLAWBACK_SECRET` included as a commented-out hint in the compose file

## Test plan

- [x] README renders correctly with three quick start tiers: registry, build from source, local dev

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)