### PR TITLE
feat(auth): replace query param secret with cookie-based login form

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,9 @@ docker compose up  # then edit docker-compose.yml to uncomment CLAWBACK_SECRET
 CLAWBACK_SECRET=my-secret make run
 ```
 
-Provide the secret via query parameter or header:
+When a secret is configured, unauthenticated browser requests redirect to a login page. Enter the secret once and a cookie keeps you logged in for the session.
 
-```
-http://localhost:8080/?secret=my-secret
-```
+For API consumers, pass the secret via header:
 
 ```bash
 curl -H "X-Clawback-Secret: my-secret" http://localhost:8080/api/sessions

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -1,41 +1,40 @@
 """Optional shared-secret authentication middleware.
 
 When the CLAWBACK_SECRET config value is set, all routes except /health
-require a matching secret via query parameter or header. When unset,
+and /login require a matching secret via cookie or header. When unset,
 all routes are accessible without authentication.
 """
 
 import hmac
 
-from flask import current_app, request
+from flask import current_app, redirect, request, url_for
 
 
 def check_secret():
     """Flask before_request hook that enforces shared-secret auth.
 
-    Returns None (allow) or a 401 tuple (deny).
+    Returns None (allow), a redirect (to /login), or a 401 tuple (deny).
     """
     secret = current_app.config.get("CLAWBACK_SECRET")
     if not secret:
         return None
 
-    if request.path == "/health":
+    if request.path in ("/health", "/login"):
         return None
 
-    provided = request.args.get("secret") or request.headers.get("X-Clawback-Secret")
+    provided = (
+        request.cookies.get("clawback_secret")
+        or request.headers.get("X-Clawback-Secret")
+    )
     if provided and hmac.compare_digest(provided, secret):
         return None
 
-    return _unauthorized_response()
+    if request.path.startswith("/api/"):
+        return _unauthorized_json()
+
+    return redirect(url_for("views.login"))
 
 
-def _unauthorized_response():
-    """Return a minimal 401 HTML error page."""
-    html = (
-        "<!doctype html>"
-        "<html><head><title>401 Unauthorized</title></head>"
-        "<body><h1>401 Unauthorized</h1>"
-        "<p>A valid secret is required to access this application.</p>"
-        "</body></html>"
-    )
-    return html, 401
+def _unauthorized_json():
+    """Return a 401 JSON response for API consumers."""
+    return {"error": "A valid secret is required"}, 401

--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -1,9 +1,123 @@
-from flask import Blueprint, send_from_directory
+import hmac
+
+from flask import (
+    Blueprint,
+    current_app,
+    make_response,
+    redirect,
+    render_template_string,
+    request,
+    send_from_directory,
+    url_for,
+)
 
 views_bp = Blueprint("views", __name__)
+
+_LOGIN_TEMPLATE = """\
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Clawback — Login</title>
+<link rel="stylesheet" href="/static/css/style.css">
+<style>
+.login {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    gap: 24px;
+}
+.login__title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-accent);
+}
+.login__form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 320px;
+}
+.login__input {
+    padding: 10px 14px;
+    border-radius: 8px;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    font-size: 1rem;
+    font-family: var(--font-sans);
+    outline: none;
+    transition: border-color 0.2s;
+}
+.login__input:focus {
+    border-color: var(--color-accent);
+}
+.login__btn {
+    padding: 10px 14px;
+    border-radius: 8px;
+    border: 1px solid var(--color-accent);
+    background-color: rgba(233, 69, 96, 0.1);
+    color: var(--color-accent);
+    font-size: 1rem;
+    font-family: var(--font-sans);
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+.login__btn:hover {
+    background-color: rgba(233, 69, 96, 0.2);
+}
+.login__error {
+    color: var(--color-accent);
+    font-size: 0.875rem;
+    text-align: center;
+}
+</style>
+</head>
+<body>
+<div class="login">
+    <div class="login__title">Clawback</div>
+    <form class="login__form" method="post" action="/login">
+        <input class="login__input" type="password" name="secret"
+               placeholder="Enter secret" autofocus required>
+        <button class="login__btn" type="submit">Log in</button>
+        {% if error %}
+        <div class="login__error">{{ error }}</div>
+        {% endif %}
+    </form>
+</div>
+</body>
+</html>
+"""
 
 
 @views_bp.route("/")
 def index():
     """Serve the single-page application."""
     return send_from_directory("static", "index.html")
+
+
+@views_bp.route("/login", methods=["GET", "POST"])
+def login():
+    """Login form and handler for cookie-based auth."""
+    secret = current_app.config.get("CLAWBACK_SECRET")
+    if not secret:
+        return redirect(url_for("views.index"))
+
+    if request.method == "GET":
+        return render_template_string(_LOGIN_TEMPLATE, error=None)
+
+    provided = request.form.get("secret", "")
+    if not provided or not hmac.compare_digest(provided, secret):
+        return render_template_string(_LOGIN_TEMPLATE, error="Invalid secret"), 401
+
+    resp = make_response(redirect(url_for("views.index")))
+    resp.set_cookie(
+        "clawback_secret",
+        provided,
+        httponly=True,
+        samesite="Lax",
+    )
+    return resp

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -43,44 +43,49 @@ def test_open_health(open_app):
         assert r.status_code == 200
 
 
-# -- Secret configured: unauthenticated requests blocked --
+# -- Secret configured: unauthenticated requests redirected/blocked --
 
 
-def test_no_secret_returns_401(secret_app):
-    """Requests without a secret return 401."""
+def test_no_secret_redirects_to_login(secret_app):
+    """Browser requests without a secret redirect to /login."""
     with secret_app.test_client() as c:
         r = c.get("/")
-        assert r.status_code == 401
+        assert r.status_code == 302
+        assert "/login" in r.headers["Location"]
 
 
-def test_wrong_secret_query_returns_401(secret_app):
-    """Requests with wrong secret in query param return 401."""
+def test_api_no_secret_returns_401(secret_app):
+    """API requests without a secret return 401 JSON."""
     with secret_app.test_client() as c:
-        r = c.get("/?secret=wrong-secret")
+        r = c.get("/api/sessions")
         assert r.status_code == 401
+        assert r.json["error"] == "A valid secret is required"
 
 
 def test_wrong_secret_header_returns_401(secret_app):
     """Requests with wrong secret in header return 401."""
     with secret_app.test_client() as c:
-        r = c.get("/", headers={"X-Clawback-Secret": "wrong-secret"})
+        r = c.get("/api/sessions", headers={"X-Clawback-Secret": "wrong-secret"})
         assert r.status_code == 401
 
 
-def test_401_body_contains_unauthorized(secret_app):
-    """401 response contains a meaningful error message."""
+def test_wrong_cookie_redirects_to_login(secret_app):
+    """Requests with wrong cookie redirect to /login."""
     with secret_app.test_client() as c:
+        c.set_cookie("clawback_secret", "wrong-secret")
         r = c.get("/")
-        assert b"401 Unauthorized" in r.data
+        assert r.status_code == 302
+        assert "/login" in r.headers["Location"]
 
 
 # -- Secret configured: authenticated requests allowed --
 
 
-def test_correct_secret_query_param(secret_app):
-    """Correct secret via query parameter grants access."""
+def test_correct_secret_cookie(secret_app):
+    """Correct secret via cookie grants access."""
     with secret_app.test_client() as c:
-        r = c.get("/?secret=test-secret-42")
+        c.set_cookie("clawback_secret", "test-secret-42")
+        r = c.get("/")
         assert r.status_code == 200
 
 
@@ -92,16 +97,19 @@ def test_correct_secret_header(secret_app):
 
 
 def test_correct_secret_api_access(secret_app):
-    """API routes are accessible with correct secret."""
+    """API routes are accessible with correct secret via header."""
     with secret_app.test_client() as c:
-        r = c.get("/api/sessions?secret=test-secret-42")
+        r = c.get(
+            "/api/sessions", headers={"X-Clawback-Secret": "test-secret-42"}
+        )
         assert r.status_code == 200
 
 
 def test_correct_secret_static_access(secret_app):
-    """Static files are accessible with correct secret."""
+    """Static files are accessible with correct cookie."""
     with secret_app.test_client() as c:
-        r = c.get("/static/css/style.css?secret=test-secret-42")
+        c.set_cookie("clawback_secret", "test-secret-42")
+        r = c.get("/static/css/style.css")
         assert r.status_code == 200
 
 
@@ -120,3 +128,69 @@ def test_health_returns_ok(secret_app):
     with secret_app.test_client() as c:
         r = c.get("/health")
         assert r.json == {"status": "ok"}
+
+
+# -- Login page --
+
+
+def test_login_page_accessible_without_auth(secret_app):
+    """GET /login is accessible without authentication."""
+    with secret_app.test_client() as c:
+        r = c.get("/login")
+        assert r.status_code == 200
+        assert b"Clawback" in r.data
+        assert b'type="password"' in r.data
+
+
+def test_login_redirects_when_no_secret_configured(open_app):
+    """GET /login redirects to index when no secret is configured."""
+    with open_app.test_client() as c:
+        r = c.get("/login")
+        assert r.status_code == 302
+        assert "/" in r.headers["Location"]
+
+
+def test_login_post_correct_secret_sets_cookie(secret_app):
+    """POST /login with correct secret sets cookie and redirects."""
+    with secret_app.test_client() as c:
+        r = c.post("/login", data={"secret": "test-secret-42"})
+        assert r.status_code == 302
+        assert "/" in r.headers["Location"]
+        cookie = next(
+            (h for h in r.headers.getlist("Set-Cookie") if "clawback_secret" in h),
+            None,
+        )
+        assert cookie is not None
+        assert "HttpOnly" in cookie
+        assert "SameSite=Lax" in cookie
+
+
+def test_login_post_wrong_secret_shows_error(secret_app):
+    """POST /login with wrong secret returns 401 with error message."""
+    with secret_app.test_client() as c:
+        r = c.post("/login", data={"secret": "wrong"})
+        assert r.status_code == 401
+        assert b"Invalid secret" in r.data
+
+
+def test_login_post_empty_secret_shows_error(secret_app):
+    """POST /login with empty secret returns 401."""
+    with secret_app.test_client() as c:
+        r = c.post("/login", data={"secret": ""})
+        assert r.status_code == 401
+
+
+def test_login_flow_end_to_end(secret_app):
+    """Full login flow: redirect → login → cookie → access."""
+    with secret_app.test_client() as c:
+        # Unauthenticated → redirect to login
+        r = c.get("/")
+        assert r.status_code == 302
+
+        # Submit correct secret
+        r = c.post("/login", data={"secret": "test-secret-42"})
+        assert r.status_code == 302
+
+        # Cookie is now set — index should work
+        r = c.get("/")
+        assert r.status_code == 200


### PR DESCRIPTION
## Summary

- Replace `?secret=` query parameter auth with a cookie-based login flow
- Unauthenticated browser requests redirect to `/login` (dark-themed login form)
- POST `/login` validates the secret and sets an `httponly` + `SameSite=Lax` cookie
- API consumers continue using the `X-Clawback-Secret` header
- API requests without auth get a 401 JSON response instead of a redirect

## Test plan

- [x] 19 auth unit tests pass (open mode, redirect, cookie auth, header auth, login form, end-to-end flow)
- [x] 56 Python unit tests pass total
- [x] 196 JS unit tests pass
- [x] 19 Playwright integration tests pass
- [x] Linter clean

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)