### PR TITLE
fix(playback): remove duration cap and slow reading pace for dense content

### DIFF
--- a/app/services/session_parser.py
+++ b/app/services/session_parser.py
@@ -11,9 +11,8 @@ Pipeline: Raw JSONL -> parse lines -> filter conversation messages ->
 import json
 from datetime import datetime, timezone
 
-BASE_WPM = 200
+BASE_WPM = 100
 MIN_DURATION = 1.0
-MAX_DURATION = 15.0
 CONVERSATION_TYPES = {"user", "assistant"}
 
 
@@ -283,7 +282,7 @@ def _calculate_durations(beats):
     for beat in beats:
         words = _count_words(beat["content"])
         raw_seconds = (words / BASE_WPM) * 60
-        beat["duration"] = max(MIN_DURATION, min(MAX_DURATION, raw_seconds))
+        beat["duration"] = max(MIN_DURATION, raw_seconds)
 
 
 def _assign_group_ids(beats):

--- a/app/static/js/parser.js
+++ b/app/static/js/parser.js
@@ -9,14 +9,11 @@
  *           assign group IDs → beat array
  */
 
-/** Words per minute for technical documentation reading pace. */
-const BASE_WPM = 200;
+/** Words per minute for dense technical content reading pace. */
+const BASE_WPM = 100;
 
 /** Minimum beat duration in seconds. */
 const MIN_DURATION = 1.0;
-
-/** Maximum beat duration in seconds. */
-const MAX_DURATION = 15.0;
 
 /**
  * Message types to keep from the JSONL stream.
@@ -336,7 +333,7 @@ function calculateDurations(beats) {
     for (const beat of beats) {
         const words = countWords(beat.content);
         const rawSeconds = (words / BASE_WPM) * 60;
-        beat.duration = Math.max(MIN_DURATION, Math.min(MAX_DURATION, rawSeconds));
+        beat.duration = Math.max(MIN_DURATION, rawSeconds);
     }
 }
 

--- a/tests/unit/js/test_parser.js
+++ b/tests/unit/js/test_parser.js
@@ -281,13 +281,13 @@ test("formats tool input — shows file_path for Read", () => {
 // ---------------------------------------------------------------------------
 console.log("\ncalculateDurations");
 
-test("calculates duration based on word count at 200 WPM", () => {
-    // 100 words at 200 WPM = 30 seconds, clamped to 15
+test("calculates duration based on word count at 100 WPM", () => {
+    // 100 words at 100 WPM = 60 seconds (no max cap)
     const beats = [
         { content: new Array(100).fill("word").join(" "), duration: 0 },
     ];
     parser.calculateDurations(beats);
-    assert.equal(beats[0].duration, 15.0, "should clamp to max 15s");
+    assert.equal(beats[0].duration, 60.0);
 });
 
 test("clamps minimum duration to 1 second", () => {
@@ -297,19 +297,28 @@ test("clamps minimum duration to 1 second", () => {
 });
 
 test("calculates proportional duration for mid-length content", () => {
-    // 50 words at 200 WPM = 15 seconds
+    // 50 words at 100 WPM = 30 seconds
     const beats = [
         { content: new Array(50).fill("word").join(" "), duration: 0 },
     ];
     parser.calculateDurations(beats);
-    assert.equal(beats[0].duration, 15.0);
+    assert.equal(beats[0].duration, 30.0);
 
-    // 20 words at 200 WPM = 6 seconds
+    // 20 words at 100 WPM = 12 seconds
     const beats2 = [
         { content: new Array(20).fill("word").join(" "), duration: 0 },
     ];
     parser.calculateDurations(beats2);
-    assert.equal(beats2[0].duration, 6.0);
+    assert.equal(beats2[0].duration, 12.0);
+});
+
+test("no max duration cap for long content", () => {
+    // 500 words at 100 WPM = 300 seconds
+    const beats = [
+        { content: new Array(500).fill("word").join(" "), duration: 0 },
+    ];
+    parser.calculateDurations(beats);
+    assert.equal(beats[0].duration, 300.0);
 });
 
 test("handles empty content", () => {
@@ -413,7 +422,6 @@ test("all beats have valid durations", () => {
     const { beats } = parser.parseSession(fixture);
     for (const beat of beats) {
         assert.ok(beat.duration >= 1.0, `beat ${beat.id} duration ${beat.duration} < 1.0`);
-        assert.ok(beat.duration <= 15.0, `beat ${beat.id} duration ${beat.duration} > 15.0`);
     }
 });
 

--- a/tests/unit/test_session_parser.py
+++ b/tests/unit/test_session_parser.py
@@ -67,11 +67,11 @@ def test_beat_categories():
             assert beat["category"] == "inner_working"
 
 
-def test_durations_are_clamped():
-    """All durations fall within [MIN_DURATION, MAX_DURATION]."""
+def test_durations_have_minimum():
+    """All durations are at least MIN_DURATION."""
     result = parse_session(_load_fixture())
     for beat in result["beats"]:
-        assert 1.0 <= beat["duration"] <= 15.0
+        assert beat["duration"] >= 1.0
 
 
 def test_group_ids_assigned_to_inner_workings():


### PR DESCRIPTION
## Summary

- Lower `BASE_WPM` from 200 to 100 to reflect dense technical content reading speed
- Remove `MAX_DURATION` (15s) cap — long content gets its full calculated duration
- Both client-side (JS) and server-side (Python) parsers updated
- ~210-word technical message: 15s (old) → 126s (new) at 1x speed

## Test plan

- [x] 197 JS unit tests pass (updated duration assertions, new no-cap test)
- [x] 56 Python unit tests pass
- [x] 19 Playwright integration tests pass

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)