### PR TITLE
feat(sessions): add debug mode to hide test sessions from students

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,7 +17,10 @@ def create_app(config=None):
 
     # Pre-parse curated sessions at startup
     cache = SessionCache()
-    cache.load(config.get("SESSIONS_DIR") if config else None)
+    cache.load(
+        sessions_dir=config.get("SESSIONS_DIR") if config else None,
+        debug=app.config.get("DEBUG", False),
+    )
     app.session_cache = cache
 
     from app.routes import register_blueprints

--- a/app/services/session_cache.py
+++ b/app/services/session_cache.py
@@ -22,8 +22,12 @@ class SessionCache:
         self._manifest = []
         self._parsed = {}
 
-    def load(self, sessions_dir=None):
-        """Parse all curated sessions from disk into memory."""
+    def load(self, sessions_dir=None, debug=False):
+        """Parse all curated sessions from disk into memory.
+
+        When debug is False, sessions with "debug": true in the manifest
+        are excluded from the listing and not parsed.
+        """
         sessions_dir = Path(sessions_dir) if sessions_dir else _SESSIONS_DIR
         manifest_path = sessions_dir / "manifest.json"
 
@@ -37,6 +41,9 @@ class SessionCache:
         if not isinstance(manifest, list):
             logger.warning("Manifest is not a list, skipping")
             return
+
+        if not debug:
+            manifest = [e for e in manifest if not e.get("debug")]
 
         self._manifest = manifest
 

--- a/sessions/curated/manifest.json
+++ b/sessions/curated/manifest.json
@@ -5,7 +5,8 @@
         "description": "A sample conversation where Claude reads and runs a Python file, then reviews a config.",
         "file": "demo-session.jsonl",
         "beat_count": 12,
-        "tags": ["tools", "code-review"]
+        "tags": ["tools", "code-review"],
+        "debug": true
     },
     {
         "id": "debugging-session",
@@ -13,7 +14,8 @@
         "description": "Watch a systematic debugging workflow — from symptom to root cause to fix, investigating a null-value bug in a profile update endpoint.",
         "file": "debugging-session.jsonl",
         "beat_count": 16,
-        "tags": ["debugging", "bug-fix", "api"]
+        "tags": ["debugging", "bug-fix", "api"],
+        "debug": true
     },
     {
         "id": "creating-clawback",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,7 +16,7 @@ FIXTURE_JSONL = os.path.join(FIXTURE_DIR, "integration-session.jsonl")
 @pytest.fixture(scope="session")
 def _app():
     """Create a Flask application for testing."""
-    return create_app({"TESTING": True})
+    return create_app({"TESTING": True, "DEBUG": True})
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_session_cache.py
+++ b/tests/unit/test_session_cache.py
@@ -16,16 +16,24 @@ CURATED_DIR = os.path.join(
 
 @pytest.fixture()
 def cache():
-    """A SessionCache loaded from the real curated sessions directory."""
+    """A SessionCache loaded with debug=True (all sessions visible)."""
     c = SessionCache()
-    c.load(CURATED_DIR)
+    c.load(CURATED_DIR, debug=True)
+    return c
+
+
+@pytest.fixture()
+def prod_cache():
+    """A SessionCache loaded with debug=False (debug sessions hidden)."""
+    c = SessionCache()
+    c.load(CURATED_DIR, debug=False)
     return c
 
 
 def test_load_populates_manifest(cache):
-    """Loading populates the manifest list."""
+    """Loading with debug=True shows all sessions."""
     sessions = cache.list_sessions()
-    assert len(sessions) >= 2
+    assert len(sessions) >= 3
 
 
 def test_manifest_entries_have_required_fields(cache):
@@ -57,6 +65,21 @@ def test_get_session_debugging(cache):
 def test_get_session_unknown_returns_none(cache):
     """get_session returns None for an unknown session ID."""
     assert cache.get_session("nonexistent") is None
+
+
+def test_debug_sessions_hidden_in_prod(prod_cache):
+    """Debug sessions are excluded when debug=False."""
+    sessions = prod_cache.list_sessions()
+    ids = [s["id"] for s in sessions]
+    assert "demo-session" not in ids
+    assert "debugging-session" not in ids
+    assert "creating-clawback" in ids
+
+
+def test_debug_sessions_not_parsed_in_prod(prod_cache):
+    """Debug sessions are not parsed when debug=False."""
+    assert prod_cache.get_session("demo-session") is None
+    assert prod_cache.get_session("debugging-session") is None
 
 
 def test_empty_cache():


### PR DESCRIPTION
## Summary

- Manifest entries with `"debug": true` are excluded unless Flask runs in debug mode
- Demo (12 beats) and Debugging (16 beats) sessions marked as debug-only
- Students only see real content ("Creating Clawback"); developers see all sessions with `FLASK_DEBUG=true`
- 2 new unit tests for debug/production filtering behavior

## Test plan

- [x] 11 session cache unit tests pass (including debug/prod filter tests)
- [x] 58 Python unit tests pass total
- [x] 19 Playwright integration tests pass (conftest sets DEBUG=True)
- [x] 197 JS unit tests pass

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)