### PR TITLE
feat(annotations): extend SessionCache with annotation loading and mutation

### DIFF
--- a/app/services/session_cache.py
+++ b/app/services/session_cache.py
@@ -8,6 +8,7 @@ import json
 import logging
 from pathlib import Path
 
+from app.services.annotation_store import AnnotationStore
 from app.services.session_parser import parse_session
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,7 @@ class SessionCache:
             manifest = [e for e in manifest if not e.get("debug")]
 
         self._manifest = manifest
+        annotation_store = AnnotationStore(sessions_dir)
 
         for entry in manifest:
             session_id = entry.get("id")
@@ -63,10 +65,12 @@ class SessionCache:
                 continue
 
             result = parse_session(file_path.read_text())
+            annotations = annotation_store.load(session_id)
             self._parsed[session_id] = {
                 "title": entry.get("title", session_id),
                 "beats": result["beats"],
                 "errors": result["errors"],
+                "annotations": annotations,
             }
 
         logger.info("Pre-parsed %d curated sessions", len(self._parsed))
@@ -78,3 +82,19 @@ class SessionCache:
     def get_session(self, session_id):
         """Return pre-parsed session data, or None if not found."""
         return self._parsed.get(session_id)
+
+    def update_annotations(self, session_id, annotations):
+        """Update cached annotations for a session without full reload."""
+        if session_id not in self._parsed:
+            return
+        self._parsed[session_id]["annotations"] = annotations
+
+    def add_session(self, session_id, entry, beats, annotations=None):
+        """Add a newly uploaded session to the cache without restart."""
+        self._manifest.append(entry)
+        self._parsed[session_id] = {
+            "title": entry.get("title", session_id),
+            "beats": beats,
+            "errors": 0,
+            "annotations": annotations,
+        }

--- a/tests/unit/test_session_cache.py
+++ b/tests/unit/test_session_cache.py
@@ -51,6 +51,7 @@ def test_get_session_returns_parsed_data(cache):
     assert data is not None
     assert "beats" in data
     assert "title" in data
+    assert "annotations" in data
     assert len(data["beats"]) == 12
 
 
@@ -115,3 +116,90 @@ def test_load_missing_session_file(tmp_path):
     c.load(str(tmp_path))
     assert c.list_sessions() == [{"id": "missing", "title": "Missing", "file": "nope.jsonl"}]
     assert c.get_session("missing") is None
+
+
+def test_annotations_null_when_no_sidecar(cache):
+    """Sessions without annotation files have annotations=None."""
+    data = cache.get_session("demo-session")
+    assert data["annotations"] is None
+
+
+def test_annotations_loaded_when_sidecar_exists(tmp_path):
+    """Sessions with annotation sidecar files have annotations populated."""
+    # Create a minimal session
+    jsonl = (
+        '{"type":"user","message":{"content":"hello"},'
+        '"uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T00:00:00Z"}\n'
+    )
+    (tmp_path / "test.jsonl").write_text(jsonl)
+
+    # Create manifest
+    manifest = [{"id": "test", "title": "Test", "file": "test.jsonl"}]
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+
+    # Create annotation sidecar
+    annotations = {
+        "session_id": "test",
+        "sections": [],
+        "callouts": [
+            {"id": "cal-1", "after_beat": 0, "style": "note", "content": "Hi"}
+        ],
+        "artifacts": [],
+    }
+    (tmp_path / "test-annotations.json").write_text(json.dumps(annotations))
+
+    c = SessionCache()
+    c.load(str(tmp_path))
+    data = c.get_session("test")
+    assert data is not None
+    assert data["annotations"] is not None
+    assert len(data["annotations"]["callouts"]) == 1
+
+
+def test_update_annotations(cache):
+    """update_annotations replaces cached annotations for a session."""
+    new_annotations = {
+        "session_id": "demo-session",
+        "sections": [],
+        "callouts": [],
+        "artifacts": [],
+    }
+    cache.update_annotations("demo-session", new_annotations)
+    data = cache.get_session("demo-session")
+    assert data["annotations"] == new_annotations
+
+
+def test_update_annotations_unknown_session(cache):
+    """update_annotations is a no-op for unknown sessions."""
+    cache.update_annotations("nonexistent", {"test": True})
+    assert cache.get_session("nonexistent") is None
+
+
+def test_add_session(cache):
+    """add_session adds a new session to both manifest and parsed data."""
+    entry = {"id": "new-session", "title": "New", "description": "Test", "file": "new.jsonl"}
+    beats = [{"id": 0, "type": "user_message", "content": "hello"}]
+    cache.add_session("new-session", entry, beats)
+
+    # Verify manifest updated
+    ids = [s["id"] for s in cache.list_sessions()]
+    assert "new-session" in ids
+
+    # Verify parsed data available
+    data = cache.get_session("new-session")
+    assert data is not None
+    assert data["title"] == "New"
+    assert len(data["beats"]) == 1
+    assert data["annotations"] is None
+
+
+def test_add_session_with_annotations(cache):
+    """add_session can include annotations."""
+    entry = {"id": "annotated", "title": "Annotated", "file": "a.jsonl"}
+    beats = [{"id": 0, "type": "user_message", "content": "hello"}]
+    annotations = {"session_id": "annotated", "sections": [], "callouts": [], "artifacts": []}
+    cache.add_session("annotated", entry, beats, annotations=annotations)
+
+    data = cache.get_session("annotated")
+    assert data["annotations"] is not None
+    assert data["annotations"]["session_id"] == "annotated"


### PR DESCRIPTION
## Summary
- Extend `SessionCache.load()` to check for `<session-id>-annotations.json` sidecar files alongside each session
- Cached session data now includes `annotations` key (dict or null)
- Add `update_annotations()` method for editor auto-save without full cache reload
- Add `add_session()` method for runtime session uploads without container restart
- 6 new unit tests covering annotation loading, cache mutation, and edge cases

## Test plan
- [x] `ruff check .` passes
- [x] 17 session cache tests pass (6 new + 11 existing)
- [x] All 96 unit tests pass (no regressions)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)