### PR TITLE
feat(annotations): add annotation API and session upload endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+
 from flask import Flask
 
 from app.config import Config
 from app.middleware.auth import check_secret
+from app.services.annotation_store import AnnotationStore
 from app.services.session_cache import SessionCache
+
+_DEFAULT_SESSIONS_DIR = Path(__file__).resolve().parent.parent / "sessions" / "curated"
 
 
 def create_app(config=None):
@@ -15,10 +20,18 @@ def create_app(config=None):
 
     app.before_request(check_secret)
 
+    # Resolve sessions directory
+    sessions_dir = config.get("SESSIONS_DIR") if config else None
+    sessions_dir = Path(sessions_dir) if sessions_dir else _DEFAULT_SESSIONS_DIR
+    app.sessions_dir = sessions_dir
+
+    # Annotation store for reading/writing sidecar files
+    app.annotation_store = AnnotationStore(sessions_dir)
+
     # Pre-parse curated sessions at startup
     cache = SessionCache()
     cache.load(
-        sessions_dir=config.get("SESSIONS_DIR") if config else None,
+        sessions_dir=str(sessions_dir),
         debug=app.config.get("DEBUG", False),
     )
     app.session_cache = cache

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1,6 +1,14 @@
-from flask import Blueprint, abort, current_app, jsonify
+import json
+import re
+import tempfile
+
+from flask import Blueprint, abort, current_app, jsonify, request
+
+from app.services.session_parser import parse_session
 
 api_bp = Blueprint("api", __name__, url_prefix="/api")
+
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MB
 
 
 @api_bp.route("/sessions")
@@ -10,6 +18,116 @@ def list_sessions():
     return jsonify({"sessions": sessions})
 
 
+# Static upload route MUST be registered before the dynamic <session_id> route,
+# otherwise Flask matches "upload" as a session_id and returns 405.
+@api_bp.route("/sessions/upload", methods=["POST"])
+def upload_session():
+    """Upload a new session JSONL with metadata."""
+    file = request.files.get("file")
+    title = request.form.get("title", "").strip()
+    description = request.form.get("description", "").strip()
+    tags_raw = request.form.get("tags", "").strip()
+
+    if not file:
+        return jsonify({"status": "error", "message": "No file provided"}), 400
+    if not title:
+        return jsonify({"status": "error", "message": "Title is required"}), 400
+
+    # Read with size limit to prevent DoS
+    content_bytes = file.read(MAX_UPLOAD_BYTES + 1)
+    if len(content_bytes) > MAX_UPLOAD_BYTES:
+        return jsonify({"status": "error", "message": "File too large"}), 413
+
+    try:
+        content = content_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return jsonify({"status": "error", "message": "File must be UTF-8 text"}), 400
+
+    if not content.strip():
+        return jsonify({"status": "error", "message": "File is empty"}), 400
+
+    # Parse to validate and get beat count
+    result = parse_session(content)
+    if not result["beats"]:
+        return jsonify({"status": "error", "message": "No parseable beats in file"}), 400
+
+    # Generate ID and filename from title
+    session_id = _slugify(title)
+    if not session_id:
+        return jsonify({"status": "error", "message": "Title produces an invalid ID"}), 400
+    filename = f"{session_id}.jsonl"
+
+    # Check for duplicate ID in cache
+    if current_app.session_cache.get_session(session_id) is not None:
+        return (
+            jsonify({"status": "error", "message": f"Session '{session_id}' already exists"}),
+            400,
+        )
+
+    # Write JSONL file to sessions directory
+    sessions_dir = current_app.sessions_dir
+    file_path = (sessions_dir / filename).resolve()
+    if not _is_path_within(file_path, sessions_dir):
+        return jsonify({"status": "error", "message": "Invalid title"}), 400
+
+    # Exclusive create to prevent TOCTOU race
+    try:
+        with open(file_path, "x") as f:
+            f.write(content)
+    except FileExistsError:
+        return (
+            jsonify({"status": "error", "message": f"Session '{session_id}' already exists"}),
+            400,
+        )
+
+    # Build manifest entry
+    tags = [t.strip() for t in tags_raw.split(",") if t.strip()] if tags_raw else []
+    entry = {
+        "id": session_id,
+        "title": title,
+        "description": description,
+        "file": filename,
+        "beat_count": len(result["beats"]),
+        "tags": tags,
+    }
+
+    # Update manifest on disk (atomic write via temp file + rename)
+    manifest_path = sessions_dir / "manifest.json"
+    manifest = []
+    if manifest_path.exists():
+        try:
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            manifest = []
+
+    manifest.append(entry)
+
+    # Write to temp file then rename for atomicity
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(sessions_dir), suffix=".json"
+    )
+    try:
+        with open(fd, "w") as f:
+            json.dump(manifest, f, indent=4)
+            f.write("\n")
+        import os
+
+        os.replace(tmp_name, str(manifest_path))
+    except Exception:
+        import os
+
+        os.unlink(tmp_name)
+        raise
+
+    # Add to in-memory cache
+    current_app.session_cache.add_session(
+        session_id, entry, result["beats"]
+    )
+
+    return jsonify({"status": "ok", "session": entry}), 201
+
+
 @api_bp.route("/sessions/<session_id>")
 def get_session(session_id):
     """Return pre-parsed beats for a curated session."""
@@ -17,3 +135,44 @@ def get_session(session_id):
     if data is None:
         abort(404)
     return jsonify(data)
+
+
+@api_bp.route("/sessions/<session_id>/annotations", methods=["PUT"])
+def save_annotations(session_id):
+    """Validate and save annotations for a curated session."""
+    cache = current_app.session_cache
+    if cache.get_session(session_id) is None:
+        return jsonify({"status": "error", "message": "Session not found"}), 404
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({"status": "error", "message": "Invalid JSON body"}), 400
+
+    store = current_app.annotation_store
+    errors = store.validate(data)
+    if errors:
+        return jsonify({"status": "error", "errors": errors}), 400
+
+    try:
+        store.save(session_id, data)
+    except ValueError as e:
+        return jsonify({"status": "error", "message": str(e)}), 400
+
+    cache.update_annotations(session_id, data)
+    return jsonify({"status": "ok"})
+
+
+def _slugify(text):
+    """Convert text to a URL-safe slug."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "-", text)
+    text = re.sub(r"-+", "-", text)
+    return text.strip("-")
+
+
+def _is_path_within(path, directory):
+    """Check that a resolved path is within the given directory."""
+    resolved = path.resolve()
+    parent = directory.resolve()
+    return resolved == parent or parent in resolved.parents

--- a/app/services/annotation_store.py
+++ b/app/services/annotation_store.py
@@ -37,7 +37,7 @@ class AnnotationStore:
     def _annotation_path(self, session_id):
         """Build the annotation file path and verify it doesn't escape the sessions dir."""
         path = (self.sessions_dir / f"{session_id}-annotations.json").resolve()
-        if not str(path).startswith(str(self.sessions_dir)):
+        if path.resolve() != self.sessions_dir and self.sessions_dir not in path.resolve().parents:
             raise ValueError(f"Session ID {session_id!r} resolves outside sessions directory")
         return path
 

--- a/app/services/session_cache.py
+++ b/app/services/session_cache.py
@@ -56,7 +56,8 @@ class SessionCache:
                 continue
 
             file_path = (sessions_dir / file_name).resolve()
-            if not str(file_path).startswith(str(sessions_dir.resolve())):
+            sessions_resolved = sessions_dir.resolve()
+            if file_path != sessions_resolved and sessions_resolved not in file_path.parents:
                 logger.warning("Session %s path escapes sessions dir, skipping", session_id)
                 continue
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,3 +1,34 @@
+import io
+import json
+
+import pytest
+
+from app import create_app
+
+
+@pytest.fixture()
+def tmp_client(tmp_path):
+    """Client with a temp sessions dir for upload/annotation tests."""
+    # Create a minimal session
+    jsonl = (
+        '{"type":"user","message":{"content":"hello"},'
+        '"uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T00:00:00Z"}\n'
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]},'
+        '"uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T00:00:01Z"}\n'
+    )
+    (tmp_path / "test-session.jsonl").write_text(jsonl)
+    manifest = [
+        {
+            "id": "test-session", "title": "Test", "file": "test-session.jsonl",
+            "beat_count": 2, "description": "A test", "tags": [],
+        }
+    ]
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+
+    app = create_app({"TESTING": True, "DEBUG": True, "SESSIONS_DIR": str(tmp_path)})
+    return app.test_client()
+
+
 def test_sessions_list_returns_200(client):
     """Sessions endpoint returns 200 with session list."""
     response = client.get("/api/sessions")
@@ -32,6 +63,14 @@ def test_get_session_returns_beats(client):
     assert len(data["beats"]) > 0
 
 
+def test_get_session_includes_annotations_key(client):
+    """Session response includes annotations field."""
+    response = client.get("/api/sessions")
+    session_id = response.json["sessions"][0]["id"]
+    response = client.get(f"/api/sessions/{session_id}")
+    assert "annotations" in response.json
+
+
 def test_get_session_beats_have_correct_structure(client):
     """Beats returned by the API have the expected structure."""
     response = client.get("/api/sessions")
@@ -50,3 +89,210 @@ def test_get_session_404_for_unknown_id(client):
     """Getting a nonexistent session returns 404."""
     response = client.get("/api/sessions/nonexistent-id-xyz")
     assert response.status_code == 404
+
+
+# --- PUT annotations tests ---
+
+
+def test_put_annotations_success(tmp_client):
+    """Valid annotation data saves successfully."""
+    data = {
+        "session_id": "test-session",
+        "sections": [],
+        "callouts": [
+            {"id": "cal-1", "after_beat": 0, "style": "note", "content": "Hello"}
+        ],
+        "artifacts": [],
+    }
+    response = tmp_client.put(
+        "/api/sessions/test-session/annotations",
+        json=data,
+    )
+    assert response.status_code == 200
+    assert response.json["status"] == "ok"
+
+    # Verify it's cached — re-fetch session
+    response = tmp_client.get("/api/sessions/test-session")
+    assert response.json["annotations"] is not None
+    assert len(response.json["annotations"]["callouts"]) == 1
+
+
+def test_put_annotations_404_unknown_session(tmp_client):
+    """PUT to unknown session returns 404."""
+    data = {"session_id": "nope", "sections": [], "callouts": [], "artifacts": []}
+    response = tmp_client.put("/api/sessions/nope/annotations", json=data)
+    assert response.status_code == 404
+
+
+def test_put_annotations_400_invalid_data(tmp_client):
+    """PUT with invalid annotation data returns 400 with errors."""
+    data = {"not": "valid"}
+    response = tmp_client.put(
+        "/api/sessions/test-session/annotations",
+        json=data,
+    )
+    assert response.status_code == 400
+    assert "errors" in response.json
+
+
+def test_put_annotations_400_no_body(tmp_client):
+    """PUT with no JSON body returns 400."""
+    response = tmp_client.put(
+        "/api/sessions/test-session/annotations",
+        data="not json",
+        content_type="text/plain",
+    )
+    assert response.status_code == 400
+    assert "Invalid JSON" in response.json["message"]
+
+
+# --- POST upload tests ---
+
+
+def test_upload_session_success(tmp_client):
+    """Uploading a valid session creates it and returns 201."""
+    jsonl = (
+        '{"type":"user","message":{"content":"new session"},'
+        '"uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T00:00:00Z"}\n'
+    )
+    data = {
+        "file": (io.BytesIO(jsonl.encode()), "new.jsonl"),
+        "title": "My New Session",
+        "description": "A fresh session",
+        "tags": "test, upload",
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 201
+    assert response.json["status"] == "ok"
+    session = response.json["session"]
+    assert session["id"] == "my-new-session"
+    assert session["title"] == "My New Session"
+    assert session["beat_count"] == 1
+    assert session["tags"] == ["test", "upload"]
+
+    # Verify it's immediately accessible
+    response = tmp_client.get("/api/sessions/my-new-session")
+    assert response.status_code == 200
+    assert len(response.json["beats"]) == 1
+
+
+def test_upload_session_missing_file(tmp_client):
+    """Upload without file returns 400."""
+    response = tmp_client.post(
+        "/api/sessions/upload",
+        data={"title": "No File"},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert "No file" in response.json["message"]
+
+
+def test_upload_session_missing_title(tmp_client):
+    """Upload without title returns 400."""
+    jsonl = (
+        '{"type":"user","message":{"content":"hi"},'
+        '"uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T00:00:00Z"}\n'
+    )
+    data = {
+        "file": (io.BytesIO(jsonl.encode()), "test.jsonl"),
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert "Title is required" in response.json["message"]
+
+
+def test_upload_session_empty_file(tmp_client):
+    """Upload with empty file returns 400."""
+    data = {
+        "file": (io.BytesIO(b""), "empty.jsonl"),
+        "title": "Empty",
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert "empty" in response.json["message"].lower()
+
+
+def test_upload_session_duplicate_title(tmp_client):
+    """Upload with title that slugifies to existing ID returns 400."""
+    jsonl = (
+        '{"type":"user","message":{"content":"hi"},'
+        '"uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T00:00:00Z"}\n'
+    )
+    data = {
+        "file": (io.BytesIO(jsonl.encode()), "test.jsonl"),
+        "title": "Test Session",  # slugifies to "test-session" which exists
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert "already exists" in response.json["message"]
+
+
+def test_upload_session_no_parseable_beats(tmp_client):
+    """Upload with JSONL that has no conversation messages returns 400."""
+    jsonl = '{"type":"progress","message":{}}\n'
+    data = {
+        "file": (io.BytesIO(jsonl.encode()), "bad.jsonl"),
+        "title": "Bad Session",
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert "No parseable beats" in response.json["message"]
+
+
+def test_upload_session_appears_in_list(tmp_client):
+    """Uploaded session appears in the sessions list endpoint."""
+    jsonl = (
+        '{"type":"user","message":{"content":"hi"},'
+        '"uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T00:00:00Z"}\n'
+    )
+    data = {
+        "file": (io.BytesIO(jsonl.encode()), "test.jsonl"),
+        "title": "Listed Session",
+    }
+    tmp_client.post(
+        "/api/sessions/upload",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    response = tmp_client.get("/api/sessions")
+    ids = [s["id"] for s in response.json["sessions"]]
+    assert "listed-session" in ids
+
+
+def test_upload_session_invalid_title_produces_empty_slug(tmp_client):
+    """Title that slugifies to empty string returns 400."""
+    jsonl = (
+        '{"type":"user","message":{"content":"hi"},'
+        '"uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T00:00:00Z"}\n'
+    )
+    data = {
+        "file": (io.BytesIO(jsonl.encode()), "test.jsonl"),
+        "title": "---",
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert "invalid ID" in response.json["message"]


### PR DESCRIPTION
## Summary
- Add `PUT /api/sessions/<id>/annotations` — validates and persists annotation sidecar files, updates cache
- Add `POST /api/sessions/upload` — accepts JSONL + metadata, persists to disk, updates manifest and cache
- Extend `GET /api/sessions/<id>` to include `annotations` field (dict or null)
- Expose `annotation_store` and `sessions_dir` on the Flask app for route access
- Fix path traversal checks across `annotation_store.py`, `session_cache.py`, and `api.py` (replaced `startswith` with proper `parents` containment)
- Upload hardening: size limit (50MB), exclusive file create (TOCTOU), atomic manifest write, empty slug guard
- 13 new API tests covering annotations PUT (success/404/400/no-body) and upload POST (success/missing-file/missing-title/empty/duplicate/no-beats/list/empty-slug)

## Test plan
- [x] `ruff check .` passes
- [x] 18 API tests pass (13 new + 5 existing)
- [x] All 109 unit tests pass (no regressions)
- [x] Code review findings addressed (route ordering, path traversal, TOCTOU, size limit, manifest resilience)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)