### PR TITLE
feat(ui): section tag sidebar blade and segmented progress bar

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -15,6 +15,7 @@
     --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
     --toolbar-height: 56px;
+    --sidebar-width: 220px;
 }
 
 /* Reset */
@@ -72,12 +73,78 @@ body {
     border-color: var(--color-text-muted);
 }
 
+/* Body layout wrapper — flex row for sidebar + main content */
+.app-body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+}
+
 /* Main content area */
 .app-main {
     flex: 1;
     padding: 24px;
     padding-bottom: calc(var(--toolbar-height) + 24px);
     overflow-y: auto;
+    min-width: 0;
+}
+
+/* -----------------------------------------------------------------------
+   Section sidebar
+   ----------------------------------------------------------------------- */
+.section-sidebar {
+    width: var(--sidebar-width);
+    flex-shrink: 0;
+    background-color: var(--color-surface);
+    border-right: 1px solid var(--color-border);
+    overflow-y: auto;
+    padding-bottom: var(--toolbar-height);
+}
+
+.section-sidebar__header {
+    padding: 16px;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.section-sidebar__title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.section-sidebar__list {
+    padding: 8px 0;
+}
+
+.section-sidebar__item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 10px 16px;
+    border-left: 3px solid transparent;
+    cursor: pointer;
+    transition: background-color 0.15s, border-left-color 0.15s;
+}
+
+.section-sidebar__item:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.section-sidebar__item--active {
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.section-sidebar__label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text);
+}
+
+.section-sidebar__range {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
 }
 
 /* -----------------------------------------------------------------------
@@ -606,6 +673,43 @@ body {
     font-size: 0.85rem;
     color: var(--color-text-muted);
     font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.toolbar__group--progress {
+    flex: 1;
+    max-width: 320px;
+    gap: 8px;
+}
+
+.toolbar__bar {
+    position: relative;
+    height: 6px;
+    border-radius: 3px;
+    overflow: hidden;
+    flex: 1;
+    background-color: var(--color-bg);
+}
+
+.toolbar__bar-segments {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    opacity: 0.4;
+}
+
+.toolbar__bar-seg {
+    height: 100%;
+}
+
+.toolbar__bar-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    background-color: rgba(255, 255, 255, 0.25);
+    transition: width 0.15s linear;
+    pointer-events: none;
 }
 
 /* -----------------------------------------------------------------------

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -31,74 +31,98 @@
         <span class="app-subtitle" x-show="sessionName" x-text="sessionName"></span>
     </header>
 
-    <main class="app-main">
-        <!-- Session picker -->
-        <div x-show="view === 'picker'">
-            <!-- Loading sessions list -->
-            <div class="picker__loading" x-show="loadingSessions">
-                <div class="spinner"></div>
-                <p>Loading sessions&#8230;</p>
+    <div class="app-body">
+        <!-- Section sidebar -->
+        <aside class="section-sidebar"
+               x-show="view === 'playback' && showSections"
+               x-transition.opacity.duration.200ms
+               x-cloak>
+            <div class="section-sidebar__header">
+                <span class="section-sidebar__title">Sections</span>
             </div>
-
-            <!-- Loading a specific session -->
-            <div class="picker__loading" x-show="loadingSession && !loadingSessions">
-                <div class="spinner"></div>
-                <p>Loading session&#8230;</p>
-            </div>
-
-            <!-- Session picker content -->
-            <div class="picker" x-show="!loadingSessions && !loadingSession">
-                <!-- Session grid -->
-                <div class="picker__grid" x-show="sessions.length > 0">
-                    <template x-for="session in sessions" :key="session.id">
-                        <div class="picker__card" @click="loadSession(session)">
-                            <h3 class="picker__card-title" x-text="session.title"></h3>
-                            <p class="picker__card-desc" x-text="session.description"></p>
-                            <span class="picker__card-meta" x-text="session.beat_count + ' beats'"></span>
-                        </div>
-                    </template>
-                </div>
-
-                <p class="picker__empty" x-show="sessions.length === 0">
-                    No curated sessions available.
-                </p>
-
-                <!-- Upload area -->
-                <div class="picker__upload">
-                    <h3 class="picker__upload-title">Upload your own session</h3>
-                    <div class="picker__upload-zone"
-                         @dragover.prevent="$el.classList.add('picker__upload-zone--active')"
-                         @dragleave="$el.classList.remove('picker__upload-zone--active')"
-                         @drop.prevent="$el.classList.remove('picker__upload-zone--active'); handleFileDrop($event)">
-                        <p>Drop a <code>.jsonl</code> file here, or</p>
-                        <label class="picker__upload-btn">
-                            Browse files
-                            <input type="file" accept=".jsonl" @change="handleFileUpload($event)" hidden>
-                        </label>
+            <div class="section-sidebar__list">
+                <template x-for="section in sectionList" :key="section.id">
+                    <div class="section-sidebar__item"
+                         :class="{ 'section-sidebar__item--active': activeSection && activeSection.id === section.id }"
+                         @click="jumpToSection(section)"
+                         :style="'border-left-color:' + getSectionColor(section.color)">
+                        <span class="section-sidebar__label" x-text="section.label"></span>
+                        <span class="section-sidebar__range"
+                              x-text="'Beats ' + (section.start_beat + 1) + '\u2013' + (section.end_beat + 1)"></span>
                     </div>
-                    <p class="picker__error" x-show="uploadError" x-text="uploadError"></p>
+                </template>
+            </div>
+        </aside>
+
+        <main class="app-main">
+            <!-- Session picker -->
+            <div x-show="view === 'picker'">
+                <!-- Loading sessions list -->
+                <div class="picker__loading" x-show="loadingSessions">
+                    <div class="spinner"></div>
+                    <p>Loading sessions&#8230;</p>
+                </div>
+
+                <!-- Loading a specific session -->
+                <div class="picker__loading" x-show="loadingSession && !loadingSessions">
+                    <div class="spinner"></div>
+                    <p>Loading session&#8230;</p>
+                </div>
+
+                <!-- Session picker content -->
+                <div class="picker" x-show="!loadingSessions && !loadingSession">
+                    <!-- Session grid -->
+                    <div class="picker__grid" x-show="sessions.length > 0">
+                        <template x-for="session in sessions" :key="session.id">
+                            <div class="picker__card" @click="loadSession(session)">
+                                <h3 class="picker__card-title" x-text="session.title"></h3>
+                                <p class="picker__card-desc" x-text="session.description"></p>
+                                <span class="picker__card-meta" x-text="session.beat_count + ' beats'"></span>
+                            </div>
+                        </template>
+                    </div>
+
+                    <p class="picker__empty" x-show="sessions.length === 0">
+                        No curated sessions available.
+                    </p>
+
+                    <!-- Upload area -->
+                    <div class="picker__upload">
+                        <h3 class="picker__upload-title">Upload your own session</h3>
+                        <div class="picker__upload-zone"
+                             @dragover.prevent="$el.classList.add('picker__upload-zone--active')"
+                             @dragleave="$el.classList.remove('picker__upload-zone--active')"
+                             @drop.prevent="$el.classList.remove('picker__upload-zone--active'); handleFileDrop($event)">
+                            <p>Drop a <code>.jsonl</code> file here, or</p>
+                            <label class="picker__upload-btn">
+                                Browse files
+                                <input type="file" accept=".jsonl" @change="handleFileUpload($event)" hidden>
+                            </label>
+                        </div>
+                        <p class="picker__error" x-show="uploadError" x-text="uploadError"></p>
+                    </div>
                 </div>
             </div>
-        </div>
 
-        <!-- Playback view -->
-        <div class="chat-area"
-             x-ref="chatArea"
-             x-show="view === 'playback'"
-             :class="{ 'chat-area--show-meta': showBeatNumbers }">
-        </div>
-    </main>
+            <!-- Playback view -->
+            <div class="chat-area"
+                 x-ref="chatArea"
+                 x-show="view === 'playback'"
+                 :class="{ 'chat-area--show-meta': showBeatNumbers }">
+            </div>
+        </main>
+    </div>
 
     <!-- Playback toolbar -->
     <div class="toolbar" x-show="view === 'playback'" x-cloak>
         <!-- Transport controls -->
         <div class="toolbar__group">
-            <button class="toolbar__btn" @click="skipToStart()" :disabled="playbackState === 'READY'" title="Skip to start">⏮</button>
-            <button class="toolbar__btn" @click="previousBeat()" :disabled="currentBeat === 0" title="Previous beat">⏪</button>
+            <button class="toolbar__btn" @click="skipToStart()" :disabled="playbackState === 'READY'" title="Skip to start">&#9198;</button>
+            <button class="toolbar__btn" @click="previousBeat()" :disabled="currentBeat === 0" title="Previous beat">&#9194;</button>
             <button class="toolbar__btn toolbar__btn--play" @click="togglePlay()" title="Play/Pause"
-                    x-text="playbackState === 'PLAYING' ? '⏸' : '▶'">▶</button>
-            <button class="toolbar__btn" @click="nextBeat()" :disabled="playbackState === 'COMPLETE'" title="Next beat">⏩</button>
-            <button class="toolbar__btn" @click="skipToEnd()" :disabled="playbackState === 'COMPLETE'" title="Skip to end">⏭</button>
+                    x-text="playbackState === 'PLAYING' ? '&#9208;' : '&#9654;'">&#9654;</button>
+            <button class="toolbar__btn" @click="nextBeat()" :disabled="playbackState === 'COMPLETE'" title="Next beat">&#9193;</button>
+            <button class="toolbar__btn" @click="skipToEnd()" :disabled="playbackState === 'COMPLETE'" title="Skip to end">&#9197;</button>
         </div>
 
         <div class="toolbar__separator"></div>
@@ -120,10 +144,30 @@
             <button class="toolbar__btn toolbar__btn--iw" :class="{ 'toolbar__btn--active': innerWorkingsMode === 'expanded' }" @click="setInnerWorkingsMode('expanded')">Expanded</button>
         </div>
 
+        <div class="toolbar__separator" x-show="sectionList.length > 0"></div>
+
+        <!-- Sections toggle -->
+        <div class="toolbar__group" x-show="sectionList.length > 0">
+            <button class="toolbar__btn toolbar__btn--iw"
+                    :class="{ 'toolbar__btn--active': showSections }"
+                    @click="toggleSections()"
+                    title="Toggle section sidebar">&#9776; Sections</button>
+        </div>
+
         <div class="toolbar__separator"></div>
 
-        <!-- Progress indicator -->
-        <div class="toolbar__group">
+        <!-- Progress bar and beat counter -->
+        <div class="toolbar__group toolbar__group--progress">
+            <div class="toolbar__bar">
+                <div class="toolbar__bar-segments">
+                    <template x-for="(seg, i) in progressSegments" :key="i">
+                        <div class="toolbar__bar-seg"
+                             :style="'flex:' + seg.width + ';background-color:' + (seg.color || 'var(--color-border)')"></div>
+                    </template>
+                </div>
+                <div class="toolbar__bar-fill"
+                     :style="'width:' + (totalBeats > 0 ? (currentBeat / totalBeats * 100) : 0) + '%'"></div>
+            </div>
             <span class="toolbar__progress" x-text="'Beat ' + currentBeat + ' / ' + totalBeats"></span>
         </div>
     </div>

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -18,6 +18,10 @@ function clawbackApp() {
         loadingSessions: true,
         loadingSession: false,
         uploadError: "",
+        showSections: false,
+        activeSection: null,
+        sectionList: [],
+        progressSegments: [{ width: 100, color: null }],
         _engine: null,
         _scroller: null,
 
@@ -76,7 +80,7 @@ function clawbackApp() {
                 })
                 .then(function (data) {
                     this.loadingSession = false;
-                    this.startPlayback(data.beats, data.title || session.title);
+                    this.startPlayback(data.beats, data.title || session.title, data.annotations);
                 }.bind(this))
                 .catch(function (err) {
                     this.loadingSession = false;
@@ -142,6 +146,10 @@ function clawbackApp() {
             this.currentBeat = 0;
             this.totalBeats = 0;
             this.sessionName = "";
+            this.showSections = false;
+            this.activeSection = null;
+            this.sectionList = [];
+            this.progressSegments = [{ width: 100, color: null }];
         },
 
         /**
@@ -149,8 +157,9 @@ function clawbackApp() {
          *
          * @param {Array<Object>} beats - Beat array from parser
          * @param {string} [name] - Session display name
+         * @param {Object|null} [annotations] - Annotation data from API
          */
-        startPlayback(beats, name) {
+        startPlayback(beats, name, annotations) {
             this._teardown("skipToStart");
 
             this.sessionName = name || "";
@@ -159,6 +168,20 @@ function clawbackApp() {
             this.totalBeats = beats.length;
             this.speed = 1.0;
             this.innerWorkingsMode = "collapsed";
+
+            // Initialize annotations if available
+            if (typeof ClawbackAnnotations !== "undefined") {
+                ClawbackAnnotations.init(annotations || null, name || "local");
+                this.sectionList = ClawbackAnnotations.getSections();
+                this.showSections = ClawbackAnnotations.hasSections();
+                this.activeSection = null;
+                this.progressSegments = this._computeProgressSegments();
+            } else {
+                this.sectionList = [];
+                this.showSections = false;
+                this.activeSection = null;
+                this.progressSegments = [{ width: 100, color: null }];
+            }
 
             var chatArea = this.$refs.chatArea;
             chatArea.innerHTML = "";
@@ -181,6 +204,7 @@ function clawbackApp() {
                 onBeat: function (beat) {
                     ClawbackRenderer.renderBeat(beat, chatArea);
                     self.currentBeat = self._engine.currentIndex;
+                    self._updateActiveSection();
                     if (self._scroller) {
                         self._scroller.scrollToBottom();
                     }
@@ -188,6 +212,7 @@ function clawbackApp() {
                 onRemoveBeat: function (beat) {
                     ClawbackRenderer.removeBeat(beat, chatArea);
                     self.currentBeat = self._engine.currentIndex;
+                    self._updateActiveSection();
                 },
                 onStateChange: function (newState, oldState) {
                     self.playbackState = newState;
@@ -268,6 +293,86 @@ function clawbackApp() {
                     mode === "expanded"
                 );
             }
+        },
+
+        /** Toggle section sidebar visibility. */
+        toggleSections() {
+            this.showSections = !this.showSections;
+        },
+
+        /** Jump playback to the start of a section. */
+        jumpToSection(section) {
+            if (!this._engine) return;
+            this._engine.jumpToBeat(section.start_beat + 1);
+            this.currentBeat = this._engine.currentIndex;
+            this._updateActiveSection();
+            if (this._scroller) {
+                this._scroller.scrollToBottom();
+            }
+        },
+
+        /** Get the hex color for a section color key. */
+        getSectionColor(colorKey) {
+            if (typeof ClawbackAnnotations !== "undefined") {
+                return ClawbackAnnotations.getColorHex(colorKey);
+            }
+            return "#95A5A6";
+        },
+
+        /** Update the active section based on the current beat. */
+        _updateActiveSection() {
+            if (typeof ClawbackAnnotations !== "undefined" && ClawbackAnnotations.hasSections()) {
+                var beatId = this.currentBeat > 0 ? this.currentBeat - 1 : null;
+                this.activeSection = beatId !== null
+                    ? ClawbackAnnotations.getSectionForBeat(beatId)
+                    : null;
+            } else {
+                this.activeSection = null;
+            }
+        },
+
+        /** Compute progress bar segments from section data. */
+        _computeProgressSegments() {
+            if (
+                !this.totalBeats ||
+                typeof ClawbackAnnotations === "undefined" ||
+                !ClawbackAnnotations.hasSections()
+            ) {
+                return [{ width: 100, color: null }];
+            }
+
+            var sections = ClawbackAnnotations.getSections();
+            sections.sort(function (a, b) { return a.start_beat - b.start_beat; });
+
+            var segments = [];
+            var lastEnd = 0;
+
+            for (var i = 0; i < sections.length; i++) {
+                var sec = sections[i];
+                var effectiveStart = Math.max(sec.start_beat, lastEnd);
+                if (effectiveStart >= sec.end_beat + 1) continue; // fully overlapped
+                if (effectiveStart > lastEnd) {
+                    segments.push({
+                        width: ((effectiveStart - lastEnd) / this.totalBeats) * 100,
+                        color: null,
+                    });
+                }
+                var beats = sec.end_beat - effectiveStart + 1;
+                segments.push({
+                    width: (beats / this.totalBeats) * 100,
+                    color: ClawbackAnnotations.getColorHex(sec.color),
+                });
+                lastEnd = sec.end_beat + 1;
+            }
+
+            if (lastEnd < this.totalBeats) {
+                segments.push({
+                    width: ((this.totalBeats - lastEnd) / this.totalBeats) * 100,
+                    color: null,
+                });
+            }
+
+            return segments;
         },
     };
 }

--- a/app/static/js/playback.js
+++ b/app/static/js/playback.js
@@ -149,6 +149,41 @@ class PlaybackEngine {
     }
 
     /**
+     * Jump to a specific beat index, rendering or removing beats as needed.
+     * Pauses playback. After calling, currentIndex === targetIndex.
+     * @param {number} targetIndex - The desired currentIndex (0 = none rendered, beats.length = all rendered)
+     */
+    jumpToBeat(targetIndex) {
+        if (targetIndex < 0) targetIndex = 0;
+        if (targetIndex > this.beats.length) targetIndex = this.beats.length;
+        if (targetIndex === this.currentIndex) return;
+
+        this._clearTimer();
+        this._remainingFraction = null;
+
+        if (targetIndex > this.currentIndex) {
+            while (this.currentIndex < targetIndex) {
+                this._renderCurrentBeat();
+            }
+        } else {
+            while (this.currentIndex > targetIndex) {
+                this.currentIndex--;
+                if (this.onRemoveBeat) {
+                    this.onRemoveBeat(this.beats[this.currentIndex]);
+                }
+            }
+        }
+
+        if (this.currentIndex >= this.beats.length) {
+            this._setState(PlaybackState.COMPLETE);
+        } else if (this.currentIndex === 0) {
+            this._setState(PlaybackState.READY);
+        } else {
+            this._setState(PlaybackState.PAUSED);
+        }
+    }
+
+    /**
      * Set the speed multiplier. Recalculates remaining wait if playing.
      * @param {number} multiplier - e.g. 0.5, 1.0, 1.5, 2.0
      */

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -44,6 +44,9 @@ global.ClawbackScroller = {
     },
 };
 
+const { ClawbackAnnotations, ANNOTATION_COLORS } = require("../../../app/static/js/annotations.js");
+global.ClawbackAnnotations = ClawbackAnnotations;
+
 const { clawbackApp } = require("../../../app/static/js/app.js");
 
 // ---------------------------------------------------------------------------
@@ -452,6 +455,171 @@ test("unhandled keys are ignored (no error)", function () {
     var evt = makeKeyEvent("KeyA");
     app.handleKeydown(evt);
     assert.equal(evt.defaultPrevented, false);
+});
+
+// ---------------------------------------------------------------------------
+// Section sidebar state
+// ---------------------------------------------------------------------------
+console.log("\nsection sidebar state");
+
+function makeSectionAnnotations() {
+    return {
+        sections: [
+            { id: "sec-1", start_beat: 0, end_beat: 2, label: "Intro", color: "blue" },
+            { id: "sec-2", start_beat: 4, end_beat: 6, label: "Main", color: "green" },
+        ],
+        callouts: [],
+        artifacts: [],
+    };
+}
+
+test("startPlayback with sections sets showSections true", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(8), "Test", makeSectionAnnotations());
+    assert.equal(app.showSections, true);
+    assert.equal(app.sectionList.length, 2);
+});
+
+test("startPlayback without annotations sets showSections false", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test");
+    assert.equal(app.showSections, false);
+    assert.deepStrictEqual(app.sectionList, []);
+});
+
+test("startPlayback with null annotations sets showSections false", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test", null);
+    assert.equal(app.showSections, false);
+});
+
+test("toggleSections flips showSections", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(8), "Test", makeSectionAnnotations());
+    assert.equal(app.showSections, true);
+    app.toggleSections();
+    assert.equal(app.showSections, false);
+    app.toggleSections();
+    assert.equal(app.showSections, true);
+});
+
+test("backToSessions resets section state", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(8), "Test", makeSectionAnnotations());
+    assert.equal(app.showSections, true);
+    app.backToSessions();
+    assert.equal(app.showSections, false);
+    assert.equal(app.activeSection, null);
+    assert.deepStrictEqual(app.sectionList, []);
+});
+
+// ---------------------------------------------------------------------------
+// Active section tracking
+// ---------------------------------------------------------------------------
+console.log("\nactive section tracking");
+
+test("activeSection updates when advancing into a section", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(8), "Test", makeSectionAnnotations());
+    assert.equal(app.activeSection, null);
+    app._engine.next(); // beat 0 rendered, currentBeat=1, active beat=0 → in sec-1
+    assert.equal(app.activeSection.id, "sec-1");
+});
+
+test("activeSection is null between sections", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(8), "Test", makeSectionAnnotations());
+    // Advance past sec-1 (beats 0-2) into gap (beat 3)
+    app._engine.next(); // beat 0
+    app._engine.next(); // beat 1
+    app._engine.next(); // beat 2
+    app._engine.next(); // beat 3 — between sections
+    assert.equal(app.activeSection, null);
+});
+
+test("activeSection updates on jumpToSection", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(8), "Test", makeSectionAnnotations());
+    var sections = app.sectionList;
+    app.jumpToSection(sections[1]); // Jump to sec-2 (start_beat=4)
+    assert.equal(app.activeSection.id, "sec-2");
+    assert.equal(app.currentBeat, 5); // beats 0-4 rendered
+});
+
+// ---------------------------------------------------------------------------
+// Progress segments
+// ---------------------------------------------------------------------------
+console.log("\nprogress segments");
+
+test("progress segments computed from sections", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(8), "Test", makeSectionAnnotations());
+    // sec-1: beats 0-2 (3 beats), gap: beat 3 (1 beat), sec-2: beats 4-6 (3 beats), gap: beat 7 (1 beat)
+    var segs = app.progressSegments;
+    assert.equal(segs.length, 4);
+    // sec-1: 3/8 = 37.5%
+    assert.equal(segs[0].width, (3 / 8) * 100);
+    assert.equal(segs[0].color, ANNOTATION_COLORS.blue);
+    // gap: 1/8 = 12.5%
+    assert.equal(segs[1].width, (1 / 8) * 100);
+    assert.equal(segs[1].color, null);
+    // sec-2: 3/8 = 37.5%
+    assert.equal(segs[2].width, (3 / 8) * 100);
+    assert.equal(segs[2].color, ANNOTATION_COLORS.green);
+    // trailing gap: 1/8 = 12.5%
+    assert.equal(segs[3].width, (1 / 8) * 100);
+    assert.equal(segs[3].color, null);
+});
+
+test("overlapping sections clamp to non-overlapping segments", function () {
+    const app = makeApp();
+    var overlapping = {
+        sections: [
+            { id: "sec-1", start_beat: 0, end_beat: 5, label: "Wide", color: "blue" },
+            { id: "sec-2", start_beat: 3, end_beat: 7, label: "Overlap", color: "green" },
+        ],
+        callouts: [],
+        artifacts: [],
+    };
+    app.startPlayback(makeBeats(10), "Test", overlapping);
+    var segs = app.progressSegments;
+    // sec-1: beats 0-5 (6 beats), sec-2 clamped: beats 6-7 (2 beats), trailing gap: beats 8-9 (2 beats)
+    assert.equal(segs.length, 3);
+    assert.equal(segs[0].width, (6 / 10) * 100);
+    assert.equal(segs[0].color, ANNOTATION_COLORS.blue);
+    assert.equal(segs[1].width, (2 / 10) * 100);
+    assert.equal(segs[1].color, ANNOTATION_COLORS.green);
+    assert.equal(segs[2].width, (2 / 10) * 100);
+    assert.equal(segs[2].color, null);
+    // Total must be 100%
+    var total = segs.reduce(function (sum, s) { return sum + s.width; }, 0);
+    assert.equal(total, 100);
+});
+
+test("fully overlapped section is skipped in segments", function () {
+    const app = makeApp();
+    var contained = {
+        sections: [
+            { id: "sec-1", start_beat: 0, end_beat: 9, label: "Full", color: "blue" },
+            { id: "sec-2", start_beat: 3, end_beat: 5, label: "Inside", color: "green" },
+        ],
+        callouts: [],
+        artifacts: [],
+    };
+    app.startPlayback(makeBeats(10), "Test", contained);
+    var segs = app.progressSegments;
+    // sec-1 covers everything, sec-2 fully inside sec-1 → skipped
+    assert.equal(segs.length, 1);
+    assert.equal(segs[0].width, 100);
+    assert.equal(segs[0].color, ANNOTATION_COLORS.blue);
+});
+
+test("no sections produces single default segment", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test");
+    assert.equal(app.progressSegments.length, 1);
+    assert.equal(app.progressSegments[0].width, 100);
+    assert.equal(app.progressSegments[0].color, null);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/js/test_playback.js
+++ b/tests/unit/js/test_playback.js
@@ -751,6 +751,98 @@ test("previous from PLAYING pauses and allows replay", () => {
 });
 
 // ---------------------------------------------------------------------------
+// jumpToBeat()
+// ---------------------------------------------------------------------------
+console.log("\njumpToBeat()");
+
+test("forward jump renders all beats up to target", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2), makeBeat(3), makeBeat(4)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.jumpToBeat(3);
+    assert.equal(rendered.length, 3);
+    assert.deepEqual(rendered.map((b) => b.id), [0, 1, 2]);
+    assert.equal(engine.currentIndex, 3);
+    assert.equal(engine.state, PlaybackState.PAUSED);
+});
+
+test("backward jump removes beats down to target", () => {
+    const removed = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2), makeBeat(3)],
+        onRemoveBeat: (beat) => removed.push(beat),
+    });
+    engine.skipToEnd();
+    engine.jumpToBeat(1);
+    assert.deepEqual(removed.map((b) => b.id), [3, 2, 1]);
+    assert.equal(engine.currentIndex, 1);
+    assert.equal(engine.state, PlaybackState.PAUSED);
+});
+
+test("jump to 0 transitions to READY", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.skipToEnd();
+    engine.jumpToBeat(0);
+    assert.equal(engine.currentIndex, 0);
+    assert.equal(engine.state, PlaybackState.READY);
+});
+
+test("jump to beats.length transitions to COMPLETE", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.jumpToBeat(2);
+    assert.equal(engine.currentIndex, 2);
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+});
+
+test("jump to same index is a no-op", () => {
+    const rendered = [];
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+        onBeat: (beat) => rendered.push(beat),
+    });
+    engine.next();
+    assert.equal(rendered.length, 1);
+    engine.jumpToBeat(1);
+    assert.equal(rendered.length, 1, "no additional beats rendered");
+});
+
+test("clamps negative target to 0", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.next();
+    engine.jumpToBeat(-5);
+    assert.equal(engine.currentIndex, 0);
+    assert.equal(engine.state, PlaybackState.READY);
+});
+
+test("clamps target beyond length to beats.length", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1)],
+    });
+    engine.jumpToBeat(999);
+    assert.equal(engine.currentIndex, 2);
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+});
+
+test("pauses playback when jumping during PLAYING", () => {
+    const engine = new PlaybackEngine({
+        beats: [makeBeat(0), makeBeat(1), makeBeat(2), makeBeat(3)],
+    });
+    engine.play();
+    assert.equal(engine.state, PlaybackState.PLAYING);
+    engine.jumpToBeat(3);
+    assert.equal(engine.state, PlaybackState.PAUSED);
+    assert.equal(engine._timer, null, "timer should be cleared");
+});
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
## Summary

- Add section navigation sidebar with active section tracking, clickable section list, and toolbar toggle
- Add segmented progress bar with color-coded section ranges and overlap clamping
- Add `PlaybackEngine.jumpToBeat()` for section navigation
- Wire `ClawbackAnnotations` into app state for section/progress integration

## Files Changed

- `playback.js` — `jumpToBeat(targetIndex)` method for forward/backward section navigation
- `app.js` — Section state management, annotation wiring, progress segments with overlap clamping
- `index.html` — `.app-body` flex wrapper, section sidebar HTML, toolbar toggle, segmented progress bar
- `style.css` — Sidebar and progress bar styling
- `test_playback.js` — 8 new `jumpToBeat()` tests
- `test_app.js` — 12 new section/progress tests (including overlap edge cases)

## Test plan

- [x] All 269 JS unit tests pass (`make test-js`)
- [x] All 128 Python tests pass (`python3 -m pytest`)
- [x] Lint passes (`ruff check .`)
- [x] Code reviewer agent ran — found and fixed 2 issues (broken `x-transition`, overlapping section segments)
- [ ] Manual: load annotated session, verify sidebar renders with colored sections
- [ ] Manual: click section in sidebar, verify playback jumps to correct beat
- [ ] Manual: toggle sidebar via toolbar button, verify show/hide with opacity transition
- [ ] Manual: verify progress bar shows colored segments matching section ranges

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)