### PR TITLE
feat(ui): callout annotation rendering and playback interleaving

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Before asking "May I have your approval to commit?", present this checklist:
 - [ ] **Unit Tests Created** - I have WRITTEN unit tests for all new functionality introduced in this commit
 - [ ] **All Tests Pass** - I have RUN the test suite and confirmed all tests pass (not "they should pass" - I actually ran them)
 - [ ] **Scripts Actually Tested** - For any new scripts (shell, Python, etc.), I have EXECUTED them and verified they work. Linting is NOT testing. Unless execution poses a serious threat of destruction, I must RUN the script and verify it works end-to-end.
+- [ ] **Code Review Passed** - I have RUN the code-reviewer agent (`subagent_type: "feature-dev:code-reviewer"`) on all changed files and addressed any high-priority issues it found. This must happen BEFORE presenting the checklist to the user.
 
 ### CRITICAL: Linting Is Not Testing
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -473,6 +473,92 @@ body {
 }
 
 /* -----------------------------------------------------------------------
+   Callout annotation cards
+   ----------------------------------------------------------------------- */
+.callout {
+    align-self: center;
+    width: 70%;
+    max-width: 560px;
+    border-radius: 12px;
+    padding: 16px 20px;
+    animation: fadeSlideUp 0.3s ease-out;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.callout--note {
+    background-color: rgba(74, 144, 217, 0.12);
+    border: 1px solid rgba(74, 144, 217, 0.3);
+}
+
+.callout--warning {
+    background-color: rgba(243, 156, 18, 0.12);
+    border: 1px solid rgba(243, 156, 18, 0.3);
+}
+
+.callout__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.callout__icon {
+    font-size: 1.1rem;
+    flex-shrink: 0;
+}
+
+.callout__title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.callout--note .callout__title {
+    color: #4A90D9;
+}
+
+.callout--warning .callout__title {
+    color: #F39C12;
+}
+
+.callout__content {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--color-text);
+}
+
+.callout__content p {
+    margin-bottom: 0.5em;
+}
+
+.callout__content p:last-child {
+    margin-bottom: 0;
+}
+
+.callout__content code {
+    font-family: var(--font-mono);
+    background-color: rgba(0, 0, 0, 0.3);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+
+.callout__content pre {
+    border-radius: 6px;
+    overflow-x: auto;
+    margin: 0.5em 0;
+}
+
+.callout__content pre code {
+    display: block;
+    background-color: rgba(0, 0, 0, 0.3);
+    padding: 12px;
+    font-size: 0.85em;
+    line-height: 1.5;
+}
+
+/* -----------------------------------------------------------------------
    Inner workings cards
    ----------------------------------------------------------------------- */
 .iw-card {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -24,6 +24,8 @@ function clawbackApp() {
         progressSegments: [{ width: 100, color: null }],
         _engine: null,
         _scroller: null,
+        _conversationBeatsRendered: 0,
+        _beatIdToMergedIndex: null,
 
         /** Called by Alpine.js on component initialization. */
         init() {
@@ -150,6 +152,8 @@ function clawbackApp() {
             this.activeSection = null;
             this.sectionList = [];
             this.progressSegments = [{ width: 100, color: null }];
+            this._conversationBeatsRendered = 0;
+            this._beatIdToMergedIndex = null;
         },
 
         /**
@@ -168,6 +172,7 @@ function clawbackApp() {
             this.totalBeats = beats.length;
             this.speed = 1.0;
             this.innerWorkingsMode = "collapsed";
+            this._conversationBeatsRendered = 0;
 
             // Initialize annotations if available
             if (typeof ClawbackAnnotations !== "undefined") {
@@ -182,6 +187,9 @@ function clawbackApp() {
                 this.activeSection = null;
                 this.progressSegments = [{ width: 100, color: null }];
             }
+
+            // Build merged beat array with callout pseudo-beats interleaved
+            var merged = this._buildMergedBeats(beats);
 
             var chatArea = this.$refs.chatArea;
             chatArea.innerHTML = "";
@@ -200,10 +208,13 @@ function clawbackApp() {
             });
 
             this._engine = new PlaybackEngine({
-                beats: beats,
+                beats: merged,
                 onBeat: function (beat) {
                     ClawbackRenderer.renderBeat(beat, chatArea);
-                    self.currentBeat = self._engine.currentIndex;
+                    if (!beat.isCallout) {
+                        self._conversationBeatsRendered++;
+                    }
+                    self.currentBeat = self._conversationBeatsRendered;
                     self._updateActiveSection();
                     if (self._scroller) {
                         self._scroller.scrollToBottom();
@@ -211,7 +222,10 @@ function clawbackApp() {
                 },
                 onRemoveBeat: function (beat) {
                     ClawbackRenderer.removeBeat(beat, chatArea);
-                    self.currentBeat = self._engine.currentIndex;
+                    if (!beat.isCallout) {
+                        self._conversationBeatsRendered--;
+                    }
+                    self.currentBeat = self._conversationBeatsRendered;
                     self._updateActiveSection();
                 },
                 onStateChange: function (newState, oldState) {
@@ -303,8 +317,12 @@ function clawbackApp() {
         /** Jump playback to the start of a section. */
         jumpToSection(section) {
             if (!this._engine) return;
-            this._engine.jumpToBeat(section.start_beat + 1);
-            this.currentBeat = this._engine.currentIndex;
+            var mergedIndex = this._beatIdToMergedIndex
+                ? this._beatIdToMergedIndex[section.start_beat]
+                : section.start_beat;
+            if (mergedIndex === undefined) mergedIndex = section.start_beat;
+            this._engine.jumpToBeat(mergedIndex + 1);
+            this.currentBeat = this._conversationBeatsRendered;
             this._updateActiveSection();
             if (this._scroller) {
                 this._scroller.scrollToBottom();
@@ -329,6 +347,65 @@ function clawbackApp() {
             } else {
                 this.activeSection = null;
             }
+        },
+
+        /**
+         * Build merged beat array with callout pseudo-beats interleaved.
+         * Also builds _beatIdToMergedIndex for section navigation.
+         *
+         * @param {Array<Object>} beats - Original conversation beats
+         * @returns {Array<Object>} Merged array with callouts inserted
+         */
+        _buildMergedBeats(beats) {
+            var hasAnnotations = typeof ClawbackAnnotations !== "undefined" &&
+                ClawbackAnnotations.hasAnnotations();
+
+            if (!hasAnnotations) {
+                this._beatIdToMergedIndex = null;
+                return beats;
+            }
+
+            var merged = [];
+            var indexMap = {};
+
+            for (var i = 0; i < beats.length; i++) {
+                indexMap[beats[i].id] = merged.length;
+                merged.push(beats[i]);
+
+                var annotations = ClawbackAnnotations.getAnnotationsAfterBeat(beats[i].id);
+                for (var j = 0; j < annotations.length; j++) {
+                    if (annotations[j].type === "callout") {
+                        var callout = annotations[j].data;
+                        merged.push({
+                            type: "callout",
+                            category: "callout",
+                            isCallout: true,
+                            calloutStyle: callout.style || "note",
+                            content: callout.content || "",
+                            calloutId: callout.id,
+                            id: "callout-" + callout.id,
+                            duration: this._calculateCalloutDuration(callout.content),
+                            group_id: null,
+                        });
+                    }
+                }
+            }
+
+            this._beatIdToMergedIndex = indexMap;
+            return merged;
+        },
+
+        /** Count words in a text string. */
+        _countWords(text) {
+            if (!text) return 0;
+            return text.split(/\s+/).filter(Boolean).length;
+        },
+
+        /** Calculate reading duration for a callout based on word count. */
+        _calculateCalloutDuration(content) {
+            var words = this._countWords(content);
+            var rawSeconds = (words / 100) * 60;
+            return Math.max(1.0, rawSeconds);
         },
 
         /** Compute progress bar segments from section data. */

--- a/app/static/js/renderer.js
+++ b/app/static/js/renderer.js
@@ -26,6 +26,10 @@ var _defaultExpanded = false;
  * @returns {HTMLElement|null} The created/updated element, or null if skipped
  */
 function renderBeat(beat, container) {
+    if (beat.type === "callout") {
+        return _renderCalloutBeat(beat, container);
+    }
+
     if (beat.category === "inner_working" && beat.group_id !== null) {
         return _renderInnerWorkingBeat(beat, container);
     }
@@ -106,6 +110,45 @@ function toggleAllInnerWorkings(_container, expanded) {
 function resetGroups() {
     _activeGroups.clear();
     _defaultExpanded = false;
+}
+
+// ---------------------------------------------------------------------------
+// Internal — callout rendering
+// ---------------------------------------------------------------------------
+
+function _renderCalloutBeat(beat, container) {
+    var card = document.createElement("div");
+    card.classList.add("callout");
+    card.dataset.beatId = String(beat.id);
+
+    var isWarning = beat.calloutStyle === "warning";
+    card.classList.add(isWarning ? "callout--warning" : "callout--note");
+
+    var header = document.createElement("div");
+    header.classList.add("callout__header");
+
+    var icon = document.createElement("span");
+    icon.classList.add("callout__icon");
+    icon.textContent = isWarning ? "\u26A0\uFE0F" : "\uD83D\uDCDD";
+
+    var title = document.createElement("span");
+    title.classList.add("callout__title");
+    title.textContent = isWarning ? "Warning" : "Instructor Note";
+
+    header.appendChild(icon);
+    header.appendChild(title);
+
+    var content = document.createElement("div");
+    content.classList.add("callout__content");
+    content.innerHTML = DOMPurify.sanitize(marked.parse(beat.content));
+    content.querySelectorAll("pre code").forEach(function (block) {
+        hljs.highlightElement(block);
+    });
+
+    card.appendChild(header);
+    card.appendChild(content);
+    container.appendChild(card);
+    return card;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -623,6 +623,177 @@ test("no sections produces single default segment", function () {
 });
 
 // ---------------------------------------------------------------------------
+// Callout interleaving
+// ---------------------------------------------------------------------------
+console.log("\ncallout interleaving");
+
+function makeCalloutAnnotations() {
+    return {
+        sections: [],
+        callouts: [
+            { id: "cal-1", after_beat: 1, style: "note", content: "Pay attention here" },
+            { id: "cal-2", after_beat: 3, style: "warning", content: "This is a complex topic with many words to read" },
+        ],
+        artifacts: [],
+    };
+}
+
+test("merged beats include callout pseudo-beats", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test", makeCalloutAnnotations());
+    // 5 conversation beats + 2 callouts = 7 merged beats
+    assert.equal(app._engine.beats.length, 7);
+});
+
+test("totalBeats tracks conversation beats only", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test", makeCalloutAnnotations());
+    assert.equal(app.totalBeats, 5);
+});
+
+test("currentBeat tracks conversation beats only during playback", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test", makeCalloutAnnotations());
+    // Advance through: beat0, beat1, callout(after_beat=1), beat2
+    app._engine.next(); // beat 0 → conversationBeats=1
+    assert.equal(app.currentBeat, 1);
+    app._engine.next(); // beat 1 → conversationBeats=2
+    assert.equal(app.currentBeat, 2);
+    app._engine.next(); // callout → conversationBeats still 2
+    assert.equal(app.currentBeat, 2);
+    app._engine.next(); // beat 2 → conversationBeats=3
+    assert.equal(app.currentBeat, 3);
+});
+
+test("previous decrements conversation beat count correctly", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test", makeCalloutAnnotations());
+    // Advance past beat 0, beat 1, callout
+    app._engine.next(); // beat 0
+    app._engine.next(); // beat 1
+    app._engine.next(); // callout
+    assert.equal(app.currentBeat, 2);
+    // Go back through callout
+    app._engine.previous(); // removes callout
+    assert.equal(app.currentBeat, 2, "callout removal should not change conversation count");
+    app._engine.previous(); // removes beat 1
+    assert.equal(app.currentBeat, 1);
+});
+
+test("skipToEnd counts all conversation beats", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test", makeCalloutAnnotations());
+    app._engine.skipToEnd();
+    assert.equal(app.currentBeat, 5);
+    assert.equal(app.totalBeats, 5);
+});
+
+test("skipToStart resets conversation beat count to 0", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test", makeCalloutAnnotations());
+    app._engine.skipToEnd();
+    app._engine.skipToStart();
+    assert.equal(app.currentBeat, 0);
+    assert.equal(app._conversationBeatsRendered, 0);
+});
+
+test("callout pseudo-beats have correct structure", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test", makeCalloutAnnotations());
+    var merged = app._engine.beats;
+    // Callout should be at index 2 (after beat 0 and beat 1)
+    var callout = merged[2];
+    assert.equal(callout.type, "callout");
+    assert.equal(callout.isCallout, true);
+    assert.equal(callout.calloutStyle, "note");
+    assert.equal(callout.content, "Pay attention here");
+    assert.equal(callout.id, "callout-cal-1");
+    assert.ok(callout.duration >= 1.0, "duration should be at least 1s");
+    assert.equal(callout.group_id, null);
+});
+
+test("callout duration calculated from word count at 100 WPM", function () {
+    const app = makeApp();
+    // 10 words → (10/100)*60 = 6 seconds
+    var tenWords = "one two three four five six seven eight nine ten";
+    var annotations = {
+        sections: [], artifacts: [],
+        callouts: [{ id: "cal-1", after_beat: 0, style: "note", content: tenWords }],
+    };
+    app.startPlayback(makeBeats(3), "Test", annotations);
+    var callout = app._engine.beats[1]; // after beat 0
+    assert.equal(callout.duration, 6);
+});
+
+test("callout duration clamps to minimum 1 second", function () {
+    const app = makeApp();
+    var annotations = {
+        sections: [], artifacts: [],
+        callouts: [{ id: "cal-1", after_beat: 0, style: "note", content: "short" }],
+    };
+    app.startPlayback(makeBeats(3), "Test", annotations);
+    var callout = app._engine.beats[1];
+    assert.equal(callout.duration, 1.0);
+});
+
+test("sessions without callouts play identically to v1.0", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test");
+    assert.equal(app._engine.beats.length, 5, "no extra beats injected");
+    assert.equal(app._beatIdToMergedIndex, null, "no index map needed");
+    app._engine.next();
+    assert.equal(app.currentBeat, 1);
+    app._engine.next();
+    assert.equal(app.currentBeat, 2);
+});
+
+test("sessions with empty annotations play identically to v1.0", function () {
+    const app = makeApp();
+    var emptyAnnotations = { sections: [], callouts: [], artifacts: [] };
+    app.startPlayback(makeBeats(5), "Test", emptyAnnotations);
+    assert.equal(app._engine.beats.length, 5, "no extra beats injected");
+});
+
+test("beatIdToMergedIndex maps conversation beat IDs to merged indices", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test", makeCalloutAnnotations());
+    // beats: [b0, b1, cal1, b2, b3, cal2, b4]
+    assert.equal(app._beatIdToMergedIndex[0], 0); // beat 0 at merged index 0
+    assert.equal(app._beatIdToMergedIndex[1], 1); // beat 1 at merged index 1
+    assert.equal(app._beatIdToMergedIndex[2], 3); // beat 2 at merged index 3 (after callout)
+    assert.equal(app._beatIdToMergedIndex[3], 4); // beat 3 at merged index 4
+    assert.equal(app._beatIdToMergedIndex[4], 6); // beat 4 at merged index 6 (after callout)
+});
+
+test("jumpToSection uses merged index for correct navigation", function () {
+    const app = makeApp();
+    var annotations = {
+        sections: [
+            { id: "sec-1", start_beat: 3, end_beat: 4, label: "Section", color: "blue" },
+        ],
+        callouts: [
+            { id: "cal-1", after_beat: 1, style: "note", content: "A note" },
+        ],
+        artifacts: [],
+    };
+    app.startPlayback(makeBeats(6), "Test", annotations);
+    // merged: [b0, b1, cal1, b2, b3, b4, b5]
+    // beat 3 is at merged index 4
+    app.jumpToSection(annotations.sections[0]);
+    // After jump, conversation beats 0-3 should be rendered = 4
+    assert.equal(app.currentBeat, 4);
+});
+
+test("backToSessions resets callout state", function () {
+    const app = makeApp();
+    app.startPlayback(makeBeats(5), "Test", makeCalloutAnnotations());
+    app._engine.skipToEnd();
+    app.backToSessions();
+    assert.equal(app._conversationBeatsRendered, 0);
+    assert.equal(app._beatIdToMergedIndex, null);
+});
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);

--- a/tests/unit/js/test_renderer.js
+++ b/tests/unit/js/test_renderer.js
@@ -58,7 +58,7 @@ function createElement(tag) {
             }
         },
         querySelector(sel) {
-            const match = sel.match(/\[data-beat-id="(\d+)"\]/);
+            const match = sel.match(/\[data-beat-id="([^"]+)"\]/);
             if (match) {
                 return (
                     this.children.find(
@@ -1071,6 +1071,98 @@ test("interleaves bubbles and inner workings cards correctly", () => {
     assert.equal(container.children.length, 3);
     assert.ok(container.children[0].classList.contains("bubble--user"));
     assert.ok(container.children[1].classList.contains("iw-card"));
+    assert.ok(container.children[2].classList.contains("bubble--assistant"));
+});
+
+// ---------------------------------------------------------------------------
+// renderBeat — callout annotations
+// ---------------------------------------------------------------------------
+console.log("\nrenderBeat — callout annotations");
+
+function makeCalloutBeat(id, style, content) {
+    return {
+        id: "callout-cal-" + id,
+        type: "callout",
+        category: "callout",
+        isCallout: true,
+        calloutStyle: style,
+        content: content || "Some callout content",
+        calloutId: "cal-" + id,
+        duration: 3,
+        group_id: null,
+    };
+}
+
+test("renders a note callout with correct CSS classes", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeCalloutBeat(1, "note"), container);
+    assert.ok(card, "should return the callout element");
+    assert.ok(card.classList.contains("callout"));
+    assert.ok(card.classList.contains("callout--note"));
+    assert.ok(!card.classList.contains("callout--warning"));
+    assert.equal(container.children.length, 1);
+});
+
+test("renders a warning callout with correct CSS classes", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeCalloutBeat(1, "warning"), container);
+    assert.ok(card.classList.contains("callout"));
+    assert.ok(card.classList.contains("callout--warning"));
+    assert.ok(!card.classList.contains("callout--note"));
+});
+
+test("note callout has correct icon and header", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeCalloutBeat(1, "note"), container);
+    const header = card.children.find((c) => c.classList.contains("callout__header"));
+    assert.ok(header, "should have a header");
+    const icon = header.children.find((c) => c.classList.contains("callout__icon"));
+    assert.equal(icon.textContent, "\uD83D\uDCDD");
+    const title = header.children.find((c) => c.classList.contains("callout__title"));
+    assert.equal(title.textContent, "Instructor Note");
+});
+
+test("warning callout has correct icon and header", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeCalloutBeat(1, "warning"), container);
+    const header = card.children.find((c) => c.classList.contains("callout__header"));
+    const icon = header.children.find((c) => c.classList.contains("callout__icon"));
+    assert.equal(icon.textContent, "\u26A0\uFE0F");
+    const title = header.children.find((c) => c.classList.contains("callout__title"));
+    assert.equal(title.textContent, "Warning");
+});
+
+test("callout content is rendered via marked + DOMPurify", () => {
+    markedCalls = [];
+    const container = makeContainer();
+    const card = renderBeat(makeCalloutBeat(1, "note", "**bold** text"), container);
+    assert.ok(markedCalls.includes("**bold** text"), "marked.parse should be called");
+    const content = card.children.find((c) => c.classList.contains("callout__content"));
+    assert.ok(content.innerHTML.includes("**bold** text"), "content should have sanitized HTML");
+});
+
+test("callout sets data-beat-id from beat.id", () => {
+    const container = makeContainer();
+    const card = renderBeat(makeCalloutBeat(42, "note"), container);
+    assert.equal(card.dataset.beatId, "callout-cal-42");
+});
+
+test("callout can be removed via removeBeat", () => {
+    const container = makeContainer();
+    renderBeat(makeCalloutBeat(1, "note"), container);
+    assert.equal(container.children.length, 1);
+    removeBeat({ id: "callout-cal-1", type: "callout", category: "callout" }, container);
+    assert.equal(container.children.length, 0);
+});
+
+test("callouts interleave with conversation bubbles", () => {
+    const container = makeContainer();
+    renderBeat(makeBeat(0, { type: "user_message", content: "Hello" }), container);
+    renderBeat(makeCalloutBeat(1, "note", "Pay attention"), container);
+    renderBeat(makeBeat(1, { type: "assistant_message", content: "Hi" }), container);
+    assert.equal(container.children.length, 3);
+    assert.ok(container.children[0].classList.contains("bubble--user"));
+    assert.ok(container.children[1].classList.contains("callout--note"));
     assert.ok(container.children[2].classList.contains("bubble--assistant"));
 });
 


### PR DESCRIPTION
## Summary

- Render callout annotations as centered, styled cards in the chat stream (note = blue, warning = amber)
- Callout content rendered via marked.js + DOMPurify + hljs for Markdown support
- Interleave callouts as pseudo-beats in the playback engine via `_buildMergedBeats()`
- Progress bar and beat counter track conversation beats only — callouts don't advance progress
- Callouts navigable via Next/Previous controls with reading-time duration at session WPM rate
- Sessions without callouts play back identically to v1.0
- Add code-reviewer agent to CLAUDE.md pre-commit checklist

## Files Changed

- `renderer.js` — `_renderCalloutBeat()` for centered callout cards with icon, header, markdown content
- `app.js` — `_buildMergedBeats()`, `_calculateCalloutDuration()`, conversation beat counter, merged index map
- `style.css` — `.callout`, `.callout--note`, `.callout--warning` with full content styling
- `CLAUDE.md` — Added code-reviewer checklist item
- `test_renderer.js` — 8 new callout rendering tests, updated querySelector mock
- `test_app.js` — 14 new callout interleaving tests

## Test plan

- [x] All 291 JS unit tests pass (`make test-js`)
- [x] All 128 Python tests pass (`python3 -m pytest`)
- [x] Lint passes (`ruff check .`)
- [x] Code reviewer agent ran — no actionable issues found
- [ ] Manual: load annotated session with callouts, verify note/warning cards render centered
- [ ] Manual: verify callouts appear at correct positions (after their `after_beat`)
- [ ] Manual: verify Next/Previous steps through callouts
- [ ] Manual: verify progress bar only counts conversation beats
- [ ] Manual: verify speed multiplier applies to callout reading duration

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)