### PR TITLE
feat(ui): add annotation editor toggle, context menu, and beat click handling

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -883,6 +883,87 @@ body {
 }
 
 /* -----------------------------------------------------------------------
+   Edit mode — hover highlights and visual indicator
+   ----------------------------------------------------------------------- */
+.chat-area--editing {
+    outline: 1px dashed rgba(233, 69, 96, 0.3);
+    outline-offset: -1px;
+}
+
+.chat-area--editing .bubble,
+.chat-area--editing .callout,
+.chat-area--editing .artifact-card {
+    cursor: pointer;
+    transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.chat-area--editing .bubble:hover,
+.chat-area--editing .callout:hover,
+.chat-area--editing .artifact-card:hover {
+    box-shadow: 0 0 0 2px var(--color-accent), 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+/* -----------------------------------------------------------------------
+   Context menu (annotation editing)
+   ----------------------------------------------------------------------- */
+.context-menu {
+    position: fixed;
+    z-index: 40;
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 4px 0;
+    min-width: 180px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.context-menu__item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 16px;
+    background: none;
+    border: none;
+    color: var(--color-text);
+    font-family: inherit;
+    font-size: 0.875rem;
+    cursor: pointer;
+    text-align: left;
+    transition: background-color 0.1s;
+}
+
+.context-menu__item:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.context-menu__icon {
+    font-size: 1rem;
+    flex-shrink: 0;
+    width: 20px;
+    text-align: center;
+}
+
+/* -----------------------------------------------------------------------
+   Edit toast notification
+   ----------------------------------------------------------------------- */
+.edit-toast {
+    position: fixed;
+    bottom: calc(var(--toolbar-height) + 56px);
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-accent);
+    border-radius: 8px;
+    padding: 8px 20px;
+    font-size: 0.875rem;
+    color: var(--color-accent);
+    z-index: 10;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+}
+
+/* -----------------------------------------------------------------------
    Alpine.js cloak — hide elements until Alpine initializes
    ----------------------------------------------------------------------- */
 [x-cloak] {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -108,7 +108,8 @@
             <div class="chat-area"
                  x-ref="chatArea"
                  x-show="view === 'playback'"
-                 :class="{ 'chat-area--show-meta': showBeatNumbers }">
+                 :class="{ 'chat-area--show-meta': showBeatNumbers, 'chat-area--editing': editMode }"
+                 @click="handleChatAreaClick($event)">
             </div>
         </main>
     </div>
@@ -156,6 +157,16 @@
 
         <div class="toolbar__separator"></div>
 
+        <!-- Edit mode toggle -->
+        <div class="toolbar__group">
+            <button class="toolbar__btn toolbar__btn--iw"
+                    :class="{ 'toolbar__btn--active': editMode }"
+                    @click="toggleEditMode()"
+                    title="Toggle annotation editing">&#9998; Edit</button>
+        </div>
+
+        <div class="toolbar__separator"></div>
+
         <!-- Progress bar and beat counter -->
         <div class="toolbar__group toolbar__group--progress">
             <div class="toolbar__bar">
@@ -194,6 +205,27 @@
         </div>
         <div class="artifact-panel__content" x-ref="artifactPanelContent"></div>
     </div>
+
+    <!-- Context menu for annotation editing -->
+    <div class="context-menu"
+         x-show="_contextMenu"
+         :style="_contextMenu ? 'left:' + _contextMenu.x + 'px;top:' + _contextMenu.y + 'px' : ''"
+         x-cloak>
+        <template x-for="item in (_contextMenu ? _contextMenu.items : [])" :key="item.action">
+            <button class="context-menu__item"
+                    @click="handleContextMenuAction(item.action)">
+                <span class="context-menu__icon" x-text="item.icon"></span>
+                <span x-text="item.label"></span>
+            </button>
+        </template>
+    </div>
+
+    <!-- Edit toast notification -->
+    <div class="edit-toast"
+         x-show="editToast"
+         x-transition
+         x-cloak
+         x-text="editToast"></div>
 
     <!-- Scroll-pause indicator -->
     <div class="scroll-pause-indicator"

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -24,6 +24,10 @@ function clawbackApp() {
         progressSegments: [{ width: 100, color: null }],
         artifactOpen: false,
         _currentArtifact: null,
+        editMode: false,
+        _contextMenu: null,
+        editToast: "",
+        _editToastTimeout: null,
         _engine: null,
         _scroller: null,
         _conversationBeatsRendered: 0,
@@ -44,7 +48,9 @@ function clawbackApp() {
 
             switch (event.code) {
                 case "Escape":
-                    if (this.artifactOpen) {
+                    if (this._contextMenu) {
+                        this.dismissContextMenu();
+                    } else if (this.artifactOpen) {
                         this.closeArtifact();
                     }
                     break;
@@ -163,6 +169,9 @@ function clawbackApp() {
             this._beatIdToMergedIndex = null;
             this.artifactOpen = false;
             this._currentArtifact = null;
+            this.editMode = false;
+            this._contextMenu = null;
+            this.editToast = "";
             var panelContent = this.$refs.artifactPanelContent;
             if (panelContent) {
                 panelContent.innerHTML = "";
@@ -332,8 +341,9 @@ function clawbackApp() {
             this.showSections = !this.showSections;
         },
 
-        /** Open the artifact panel and pause playback. */
+        /** Open the artifact panel and pause playback. Disabled in edit mode. */
         openArtifact(beat) {
+            if (this.editMode) return;
             if (this._engine && this.playbackState === "PLAYING") {
                 this._engine.pause();
             }
@@ -353,6 +363,101 @@ function clawbackApp() {
             if (panelContent) {
                 panelContent.innerHTML = "";
             }
+        },
+
+        /** Toggle annotation editing mode. */
+        toggleEditMode() {
+            this.editMode = !this.editMode;
+            this.dismissContextMenu();
+        },
+
+        /**
+         * Handle clicks in the chat area during edit mode.
+         * Shows a context menu anchored to the clicked beat or annotation.
+         *
+         * @param {Event} event - Click event from the chat area
+         */
+        handleChatAreaClick(event) {
+            if (!this.editMode) return;
+
+            var target = event.target.closest(".bubble, .callout, .artifact-card");
+            if (!target) {
+                this.dismissContextMenu();
+                return;
+            }
+
+            if (this.playbackState === "PLAYING") {
+                this._showEditToast("Pause playback to edit");
+                return;
+            }
+
+            var beatId = target.dataset.beatId;
+            var isAnnotation = target.classList.contains("callout") ||
+                target.classList.contains("artifact-card");
+
+            var items;
+            if (isAnnotation) {
+                items = [
+                    { label: "Edit", action: "edit-annotation", icon: "\u270F\uFE0F" },
+                    { label: "Delete", action: "delete-annotation", icon: "\uD83D\uDDD1\uFE0F" },
+                ];
+            } else {
+                items = [
+                    { label: "Start Section", action: "start-section", icon: "\uD83D\uDCCC" },
+                    { label: "Add Note", action: "add-note", icon: "\uD83D\uDCDD" },
+                    { label: "Add Warning", action: "add-warning", icon: "\u26A0\uFE0F" },
+                    { label: "Attach Artifact", action: "attach-artifact", icon: "\uD83D\uDCC4" },
+                ];
+            }
+
+            // Position menu, clamped to viewport edges
+            var menuWidth = 200;
+            var menuHeight = items.length * 44 + 16;
+            var viewW = typeof window !== "undefined" ? window.innerWidth : 1024;
+            var viewH = typeof window !== "undefined" ? window.innerHeight : 768;
+            var x = Math.min(event.clientX, viewW - menuWidth - 8);
+            var y = Math.min(event.clientY, viewH - menuHeight - 8);
+            x = Math.max(8, x);
+            y = Math.max(8, y);
+
+            this._contextMenu = {
+                x: x,
+                y: y,
+                items: items,
+                beatId: beatId,
+                isAnnotation: isAnnotation,
+            };
+        },
+
+        /** Dismiss the context menu. */
+        dismissContextMenu() {
+            this._contextMenu = null;
+        },
+
+        /**
+         * Handle a context menu action selection.
+         * Stores the selected action details for downstream handlers.
+         *
+         * @param {string} action - The action key (e.g., "add-note", "delete-annotation")
+         */
+        handleContextMenuAction(action) {
+            var beatId = this._contextMenu ? this._contextMenu.beatId : null;
+            var isAnnotation = this._contextMenu ? this._contextMenu.isAnnotation : false;
+            this.dismissContextMenu();
+            // Annotation creation/editing dispatched in later issues (#50-#52)
+        },
+
+        /** Show a temporary edit-mode toast message. */
+        _showEditToast(msg) {
+            this.editToast = msg;
+            if (this._editToastTimeout) {
+                clearTimeout(this._editToastTimeout);
+            }
+            var self = this;
+            this._editToastTimeout = setTimeout(function () {
+                self.editToast = "";
+                self._editToastTimeout = null;
+            }, 2000);
         },
 
         /** Jump playback to the start of a section. */

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -1062,6 +1062,233 @@ test("openArtifact calls renderArtifactPanel on renderer", function () {
 });
 
 // ---------------------------------------------------------------------------
+// Edit mode toggle
+// ---------------------------------------------------------------------------
+console.log("\nedit mode toggle");
+
+test("editMode defaults to false", function () {
+    const app = makeApp(5);
+    assert.equal(app.editMode, false);
+});
+
+test("toggleEditMode flips editMode", function () {
+    const app = makeApp(5);
+    app.toggleEditMode();
+    assert.equal(app.editMode, true);
+    app.toggleEditMode();
+    assert.equal(app.editMode, false);
+});
+
+test("toggleEditMode dismisses context menu", function () {
+    const app = makeApp(5);
+    app._contextMenu = { x: 0, y: 0, items: [], beatId: "0" };
+    app.toggleEditMode();
+    assert.equal(app._contextMenu, null);
+});
+
+test("backToSessions resets edit state", function () {
+    const app = makeApp(5);
+    app.editMode = true;
+    app._contextMenu = { x: 0, y: 0, items: [], beatId: "0" };
+    app.editToast = "test";
+    app.backToSessions();
+    assert.equal(app.editMode, false);
+    assert.equal(app._contextMenu, null);
+    assert.equal(app.editToast, "");
+});
+
+// ---------------------------------------------------------------------------
+// Context menu — handleChatAreaClick
+// ---------------------------------------------------------------------------
+console.log("\ncontext menu — handleChatAreaClick");
+
+function makeMockElement(beatId, type) {
+    return {
+        dataset: { beatId: String(beatId) },
+        classList: {
+            contains: function (cls) { return cls === type; },
+        },
+    };
+}
+
+function makeClickEvent(x, y, targetElement) {
+    var stopped = false;
+    return {
+        clientX: x || 100,
+        clientY: y || 100,
+        stopPropagation: function () { stopped = true; },
+        get propagationStopped() { return stopped; },
+        target: {
+            closest: function () { return targetElement || null; },
+        },
+    };
+}
+
+test("does nothing when editMode is off", function () {
+    const app = makeApp(5);
+    app.editMode = false;
+    var el = makeMockElement(0, "bubble");
+    app.handleChatAreaClick(makeClickEvent(100, 100, el));
+    assert.equal(app._contextMenu, null);
+});
+
+test("shows context menu on beat click when editMode + paused", function () {
+    const app = makeApp(5);
+    app.editMode = true;
+    app._engine.next();
+    assert.notEqual(app.playbackState, "PLAYING");
+    var el = makeMockElement(0, "bubble");
+    app.handleChatAreaClick(makeClickEvent(100, 200, el));
+    assert.notEqual(app._contextMenu, null);
+    assert.equal(app._contextMenu.beatId, "0");
+    assert.equal(app._contextMenu.isAnnotation, false);
+    assert.equal(app._contextMenu.items.length, 4);
+});
+
+test("beat context menu has correct items", function () {
+    const app = makeApp(5);
+    app.editMode = true;
+    app._engine.next();
+    var el = makeMockElement(0, "bubble");
+    app.handleChatAreaClick(makeClickEvent(100, 100, el));
+    var actions = app._contextMenu.items.map(function (i) { return i.action; });
+    assert.deepStrictEqual(actions, [
+        "start-section", "add-note", "add-warning", "attach-artifact"
+    ]);
+});
+
+test("annotation context menu has Edit and Delete items", function () {
+    const app = makeApp(5);
+    app.editMode = true;
+    app._engine.next();
+    var el = makeMockElement("callout-cal-1", "callout");
+    app.handleChatAreaClick(makeClickEvent(100, 100, el));
+    assert.notEqual(app._contextMenu, null);
+    assert.equal(app._contextMenu.isAnnotation, true);
+    assert.equal(app._contextMenu.items.length, 2);
+    var actions = app._contextMenu.items.map(function (i) { return i.action; });
+    assert.deepStrictEqual(actions, ["edit-annotation", "delete-annotation"]);
+});
+
+test("artifact-card click in editMode shows annotation menu", function () {
+    const app = makeApp(5);
+    app.editMode = true;
+    app._engine.next();
+    var el = makeMockElement("artifact-art-1", "artifact-card");
+    app.handleChatAreaClick(makeClickEvent(100, 100, el));
+    assert.notEqual(app._contextMenu, null);
+    assert.equal(app._contextMenu.isAnnotation, true);
+});
+
+test("shows toast when editMode + PLAYING", function () {
+    const app = makeApp(5);
+    app.editMode = true;
+    app._engine.play();
+    assert.equal(app.playbackState, "PLAYING");
+    var el = makeMockElement(0, "bubble");
+    app.handleChatAreaClick(makeClickEvent(100, 100, el));
+    assert.equal(app._contextMenu, null);
+    assert.equal(app.editToast, "Pause playback to edit");
+});
+
+test("dismisses menu when clicking empty space", function () {
+    const app = makeApp(5);
+    app.editMode = true;
+    app._contextMenu = { x: 0, y: 0, items: [], beatId: "0" };
+    // Click event with no target element (empty space)
+    app.handleChatAreaClick(makeClickEvent(100, 100, null));
+    assert.equal(app._contextMenu, null);
+});
+
+test("context menu position is clamped to viewport", function () {
+    const app = makeApp(5);
+    app.editMode = true;
+    app._engine.next();
+    var el = makeMockElement(0, "bubble");
+    // Click at far right/bottom edge
+    app.handleChatAreaClick(makeClickEvent(9999, 9999, el));
+    assert.ok(app._contextMenu.x < 9999, "x should be clamped");
+    assert.ok(app._contextMenu.y < 9999, "y should be clamped");
+    assert.ok(app._contextMenu.x >= 8, "x should not be negative");
+    assert.ok(app._contextMenu.y >= 8, "y should not be negative");
+});
+
+test("Escape dismisses context menu before artifact panel", function () {
+    const app = makeApp(5);
+    app.$refs.artifactPanelContent = { innerHTML: "" };
+    app._contextMenu = { x: 0, y: 0, items: [], beatId: "0" };
+    app.artifactOpen = true;
+    app.handleKeydown(makeKeyEvent("Escape"));
+    assert.equal(app._contextMenu, null, "context menu should be dismissed");
+    assert.equal(app.artifactOpen, true, "artifact panel should remain open");
+});
+
+test("Escape closes artifact panel when no context menu", function () {
+    const app = makeApp(5);
+    app.$refs.artifactPanelContent = { innerHTML: "" };
+    app.artifactOpen = true;
+    app._currentArtifact = {};
+    app.handleKeydown(makeKeyEvent("Escape"));
+    assert.equal(app.artifactOpen, false);
+});
+
+test("dismissContextMenu clears _contextMenu", function () {
+    const app = makeApp(5);
+    app._contextMenu = { x: 0, y: 0, items: [], beatId: "0" };
+    app.dismissContextMenu();
+    assert.equal(app._contextMenu, null);
+});
+
+test("handleContextMenuAction dismisses menu", function () {
+    const app = makeApp(5);
+    app._contextMenu = { x: 0, y: 0, items: [], beatId: "0", isAnnotation: false };
+    app.handleContextMenuAction("add-note");
+    assert.equal(app._contextMenu, null);
+});
+
+// ---------------------------------------------------------------------------
+// Edit mode — openArtifact interaction
+// ---------------------------------------------------------------------------
+console.log("\nedit mode — openArtifact interaction");
+
+test("openArtifact is blocked when editMode is on", function () {
+    const app = makeApp(5);
+    app.$refs.artifactPanelContent = {};
+    app.editMode = true;
+    app.openArtifact({ type: "artifact", artifactTitle: "X", artifactContent: "Y" });
+    assert.equal(app.artifactOpen, false, "panel should not open in edit mode");
+    assert.equal(app._currentArtifact, null);
+});
+
+test("openArtifact works when editMode is off", function () {
+    const app = makeApp(5);
+    app.$refs.artifactPanelContent = {};
+    app.editMode = false;
+    app.openArtifact({ type: "artifact", artifactTitle: "X", artifactContent: "Y" });
+    assert.equal(app.artifactOpen, true);
+});
+
+// ---------------------------------------------------------------------------
+// Edit toast
+// ---------------------------------------------------------------------------
+console.log("\nedit toast");
+
+test("_showEditToast sets editToast message", function () {
+    const app = makeApp(5);
+    app._showEditToast("Test message");
+    assert.equal(app.editToast, "Test message");
+});
+
+test("_showEditToast sets a timeout handle for auto-clear", function () {
+    const app = makeApp(5);
+    app._showEditToast("Test");
+    assert.equal(app.editToast, "Test");
+    assert.notEqual(app._editToastTimeout, null, "timeout should be set");
+    // Clean up timeout to prevent interference
+    clearTimeout(app._editToastTimeout);
+});
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
## Summary
- Add "Edit Annotations" toolbar toggle with visual indicator (active button state + dashed outline on chat area)
- Implement beat/annotation click handling: beats show creation menu (Start Section, Add Note, Add Warning, Attach Artifact); annotations show Edit/Delete menu
- Context menu positions are viewport-edge-clamped to avoid clipping
- Edit toast shows "Pause playback to edit" when clicking beats during active playback
- Escape key dismisses context menu with priority over artifact panel close
- Opening artifact panel is blocked in edit mode to prevent conflict with annotation click handling

## Test plan
- [x] 4 edit mode toggle tests (default state, flip, context menu dismiss, backToSessions reset)
- [x] 8 context menu click handling tests (beat menu, annotation menu, artifact-card, PLAYING toast, empty space dismiss, viewport clamping)
- [x] 4 Escape key priority tests (context menu vs artifact panel)
- [x] 2 openArtifact interaction tests (blocked in editMode, works when off)
- [x] 2 edit toast tests (message set, timeout handle)
- [x] All 301 tests pass (107 app + 66 renderer + 128 Python)
- [x] Code-reviewer found and fixed: @click.outside race condition, overlapping toast position

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)