### PR TITLE
feat(ui): add callout and artifact creation via inline editors (#51)

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1126,6 +1126,136 @@ body {
 }
 
 /* -----------------------------------------------------------------------
+   Inline annotation editor
+   ----------------------------------------------------------------------- */
+.inline-editor {
+    margin: 8px 0;
+    padding: 16px;
+    border-radius: 10px;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-surface);
+    max-width: 720px;
+}
+
+.inline-editor--note {
+    border-left: 3px solid #5B9BD5;
+}
+
+.inline-editor--warning {
+    border-left: 3px solid #E67E22;
+}
+
+.inline-editor--artifact {
+    border-left: 3px solid #9B59B6;
+}
+
+.inline-editor__header {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    margin-bottom: 10px;
+}
+
+.inline-editor__textarea {
+    width: 100%;
+    min-height: 60px;
+    padding: 10px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font-family: inherit;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+    transition: border-color 0.15s;
+    box-sizing: border-box;
+}
+
+.inline-editor__textarea:focus {
+    border-color: var(--color-accent);
+}
+
+.inline-editor__input {
+    width: 100%;
+    padding: 8px 12px;
+    margin-bottom: 8px;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font-family: inherit;
+    font-size: 0.875rem;
+    outline: none;
+    transition: border-color 0.15s;
+    box-sizing: border-box;
+}
+
+.inline-editor__input:focus {
+    border-color: var(--color-accent);
+}
+
+.inline-editor__select {
+    width: 100%;
+    padding: 8px 12px;
+    margin-bottom: 8px;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font-family: inherit;
+    font-size: 0.875rem;
+    outline: none;
+    cursor: pointer;
+    box-sizing: border-box;
+}
+
+.inline-editor__error {
+    color: #E74C3C;
+    font-size: 0.8rem;
+    min-height: 1.2em;
+    margin-top: 4px;
+}
+
+.inline-editor__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.inline-editor__cancel,
+.inline-editor__save {
+    padding: 6px 16px;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.inline-editor__cancel {
+    background: none;
+    border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+}
+
+.inline-editor__cancel:hover {
+    color: var(--color-text);
+    border-color: var(--color-text-muted);
+}
+
+.inline-editor__save {
+    background-color: var(--color-accent);
+    border: 1px solid var(--color-accent);
+    color: #fff;
+}
+
+.inline-editor__save:hover {
+    background-color: var(--color-accent-hover);
+}
+
+/* -----------------------------------------------------------------------
    Edit toast notification
    ----------------------------------------------------------------------- */
 .edit-toast {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -30,6 +30,7 @@ function clawbackApp() {
         _editToastTimeout: null,
         _sectionForm: null,
         _pendingSection: null,
+        _inlineEditor: null,
         _engine: null,
         _scroller: null,
         _conversationBeatsRendered: 0,
@@ -50,6 +51,8 @@ function clawbackApp() {
                     this.cancelSectionForm();
                 } else if (this._pendingSection) {
                     this.cancelPendingSection();
+                } else if (this._inlineEditor) {
+                    this._dismissInlineEditor();
                 } else if (this._contextMenu) {
                     this.dismissContextMenu();
                 } else if (this.artifactOpen) {
@@ -183,6 +186,7 @@ function clawbackApp() {
             this.editToast = "";
             this._sectionForm = null;
             this._pendingSection = null;
+            this._dismissInlineEditor();
             var panelContent = this.$refs.artifactPanelContent;
             if (panelContent) {
                 panelContent.innerHTML = "";
@@ -406,9 +410,13 @@ function clawbackApp() {
                 return;
             }
 
+            // Clicks inside the inline editor are handled by the editor itself
+            if (event.target.closest(".inline-editor")) return;
+
             var target = event.target.closest(".bubble, .callout, .artifact-card");
             if (!target) {
                 this.dismissContextMenu();
+                this._dismissInlineEditor();
                 return;
             }
 
@@ -471,10 +479,17 @@ function clawbackApp() {
             var isAnnotation = this._contextMenu ? this._contextMenu.isAnnotation : false;
             this.dismissContextMenu();
 
-            if (action === "start-section" && beatId !== null) {
+            if (beatId === null) return;
+
+            if (action === "start-section") {
                 this._startSectionCreation(parseInt(beatId, 10));
+            } else if (action === "add-note") {
+                this._openCalloutEditor(parseInt(beatId, 10), "note");
+            } else if (action === "add-warning") {
+                this._openCalloutEditor(parseInt(beatId, 10), "warning");
+            } else if (action === "attach-artifact") {
+                this._openArtifactEditor(parseInt(beatId, 10));
             }
-            // Other actions dispatched in later issues (#51-#52)
         },
 
         /** Show a temporary edit-mode toast message. */
@@ -563,6 +578,320 @@ function clawbackApp() {
                 this.progressSegments = this._computeProgressSegments();
                 this._updateActiveSection();
             }
+        },
+
+
+        // ---------------------------------------------------------------
+        // Inline annotation editors
+        // ---------------------------------------------------------------
+
+        /**
+         * Open an inline callout editor below the target beat.
+         *
+         * @param {number} beatId - The beat ID to attach the callout to
+         * @param {string} style - "note" or "warning"
+         */
+        _openCalloutEditor(beatId, style) {
+            this._dismissInlineEditor();
+            var chatArea = this.$refs.chatArea;
+            if (!chatArea) return;
+            var beatEl = chatArea.querySelector('[data-beat-id="' + beatId + '"].bubble');
+            if (!beatEl) return;
+
+            var form = document.createElement("div");
+            form.className = "inline-editor inline-editor--" + style;
+
+            var header = document.createElement("div");
+            header.className = "inline-editor__header";
+            header.textContent = style === "warning" ? "\u26A0\uFE0F Add Warning" : "\uD83D\uDCDD Add Note";
+            form.appendChild(header);
+
+            var textarea = document.createElement("textarea");
+            textarea.className = "inline-editor__textarea";
+            textarea.placeholder = style === "warning" ? "Warning text\u2026" : "Note text\u2026";
+            textarea.rows = 3;
+            form.appendChild(textarea);
+
+            var errorMsg = document.createElement("div");
+            errorMsg.className = "inline-editor__error";
+            form.appendChild(errorMsg);
+
+            var footer = document.createElement("div");
+            footer.className = "inline-editor__footer";
+
+            var cancelBtn = document.createElement("button");
+            cancelBtn.className = "inline-editor__cancel";
+            cancelBtn.textContent = "Cancel";
+            footer.appendChild(cancelBtn);
+
+            var saveBtn = document.createElement("button");
+            saveBtn.className = "inline-editor__save";
+            saveBtn.textContent = "Save";
+            footer.appendChild(saveBtn);
+
+            form.appendChild(footer);
+
+            beatEl.insertAdjacentElement("afterend", form);
+            textarea.focus();
+
+            var self = this;
+            this._inlineEditor = {
+                type: "callout",
+                beatId: beatId,
+                style: style,
+                element: form,
+                textarea: textarea,
+                errorMsg: errorMsg,
+            };
+
+            cancelBtn.addEventListener("click", function () {
+                self._dismissInlineEditor();
+            });
+
+            saveBtn.addEventListener("click", function () {
+                self._saveCallout();
+            });
+
+            textarea.addEventListener("keydown", function (e) {
+                if (e.code === "Escape") {
+                    e.stopPropagation();
+                    self._dismissInlineEditor();
+                }
+            });
+        },
+
+        /** Save the current callout from the inline editor. */
+        _saveCallout() {
+            if (!this._inlineEditor || this._inlineEditor.type !== "callout") return;
+            var content = this._inlineEditor.textarea.value.trim();
+            if (!content) {
+                this._inlineEditor.errorMsg.textContent = "Content cannot be empty";
+                return;
+            }
+
+            var beatId = this._inlineEditor.beatId;
+            var style = this._inlineEditor.style;
+
+            if (typeof ClawbackAnnotations === "undefined") {
+                this._showEditToast("Annotations not available");
+                return;
+            }
+
+            var callout = ClawbackAnnotations.createCallout(beatId, style, content);
+            this._renderInlineAnnotation(beatId, {
+                type: "callout",
+                category: "callout",
+                isCallout: true,
+                calloutStyle: style,
+                content: content,
+                calloutId: callout.id,
+                id: "callout-" + callout.id,
+                group_id: null,
+            });
+
+            var self = this;
+            ClawbackAnnotations.save().catch(function () {
+                self._showEditToast("Save failed — callout may not persist");
+            });
+            this._dismissInlineEditor();
+        },
+
+        /**
+         * Open an inline artifact editor below the target beat.
+         *
+         * @param {number} beatId - The beat ID to attach the artifact to
+         */
+        _openArtifactEditor(beatId) {
+            this._dismissInlineEditor();
+            var chatArea = this.$refs.chatArea;
+            if (!chatArea) return;
+            var beatEl = chatArea.querySelector('[data-beat-id="' + beatId + '"].bubble');
+            if (!beatEl) return;
+
+            var form = document.createElement("div");
+            form.className = "inline-editor inline-editor--artifact";
+
+            var header = document.createElement("div");
+            header.className = "inline-editor__header";
+            header.textContent = "\uD83D\uDCC4 Attach Artifact";
+            form.appendChild(header);
+
+            // Title
+            var titleInput = document.createElement("input");
+            titleInput.className = "inline-editor__input";
+            titleInput.type = "text";
+            titleInput.placeholder = "Artifact title";
+            form.appendChild(titleInput);
+
+            // Description
+            var descInput = document.createElement("input");
+            descInput.className = "inline-editor__input";
+            descInput.type = "text";
+            descInput.placeholder = "Brief description (optional)";
+            form.appendChild(descInput);
+
+            // Content type dropdown
+            var typeSelect = document.createElement("select");
+            typeSelect.className = "inline-editor__select";
+            var mdOpt = document.createElement("option");
+            mdOpt.value = "markdown";
+            mdOpt.textContent = "Markdown";
+            typeSelect.appendChild(mdOpt);
+            var codeOpt = document.createElement("option");
+            codeOpt.value = "code";
+            codeOpt.textContent = "Code";
+            typeSelect.appendChild(codeOpt);
+            form.appendChild(typeSelect);
+
+            // Content textarea
+            var textarea = document.createElement("textarea");
+            textarea.className = "inline-editor__textarea";
+            textarea.placeholder = "Artifact content\u2026";
+            textarea.rows = 6;
+            form.appendChild(textarea);
+
+            var errorMsg = document.createElement("div");
+            errorMsg.className = "inline-editor__error";
+            form.appendChild(errorMsg);
+
+            var footer = document.createElement("div");
+            footer.className = "inline-editor__footer";
+
+            var cancelBtn = document.createElement("button");
+            cancelBtn.className = "inline-editor__cancel";
+            cancelBtn.textContent = "Cancel";
+            footer.appendChild(cancelBtn);
+
+            var saveBtn = document.createElement("button");
+            saveBtn.className = "inline-editor__save";
+            saveBtn.textContent = "Save";
+            footer.appendChild(saveBtn);
+
+            form.appendChild(footer);
+
+            beatEl.insertAdjacentElement("afterend", form);
+            titleInput.focus();
+
+            var self = this;
+            this._inlineEditor = {
+                type: "artifact",
+                beatId: beatId,
+                element: form,
+                titleInput: titleInput,
+                descInput: descInput,
+                typeSelect: typeSelect,
+                textarea: textarea,
+                errorMsg: errorMsg,
+            };
+
+            cancelBtn.addEventListener("click", function () {
+                self._dismissInlineEditor();
+            });
+
+            saveBtn.addEventListener("click", function () {
+                self._saveArtifact();
+            });
+
+            textarea.addEventListener("keydown", function (e) {
+                if (e.code === "Escape") {
+                    e.stopPropagation();
+                    self._dismissInlineEditor();
+                }
+            });
+            titleInput.addEventListener("keydown", function (e) {
+                if (e.code === "Escape") {
+                    e.stopPropagation();
+                    self._dismissInlineEditor();
+                }
+            });
+            descInput.addEventListener("keydown", function (e) {
+                if (e.code === "Escape") {
+                    e.stopPropagation();
+                    self._dismissInlineEditor();
+                }
+            });
+            typeSelect.addEventListener("keydown", function (e) {
+                if (e.code === "Escape") {
+                    e.stopPropagation();
+                    self._dismissInlineEditor();
+                }
+            });
+        },
+
+        /** Save the current artifact from the inline editor. */
+        _saveArtifact() {
+            if (!this._inlineEditor || this._inlineEditor.type !== "artifact") return;
+            var title = this._inlineEditor.titleInput.value.trim();
+            var description = this._inlineEditor.descInput.value.trim();
+            var contentType = this._inlineEditor.typeSelect.value;
+            var content = this._inlineEditor.textarea.value.trim();
+
+            if (!title) {
+                this._inlineEditor.errorMsg.textContent = "Title cannot be empty";
+                return;
+            }
+            if (!content) {
+                this._inlineEditor.errorMsg.textContent = "Content cannot be empty";
+                return;
+            }
+
+            var beatId = this._inlineEditor.beatId;
+
+            if (typeof ClawbackAnnotations === "undefined") {
+                this._showEditToast("Annotations not available");
+                return;
+            }
+
+            var artifact = ClawbackAnnotations.createArtifact(beatId, title, description, contentType, content);
+            this._renderInlineAnnotation(beatId, {
+                type: "artifact",
+                category: "artifact",
+                isArtifact: true,
+                artifactTitle: title,
+                artifactDescription: description,
+                artifactContent: content,
+                contentType: contentType,
+                content: title + " " + description,
+                artifactId: artifact.id,
+                id: "artifact-" + artifact.id,
+                group_id: null,
+            });
+
+            var self = this;
+            ClawbackAnnotations.save().catch(function () {
+                self._showEditToast("Save failed — artifact may not persist");
+            });
+            this._dismissInlineEditor();
+        },
+
+        /**
+         * Render a newly created annotation into the chat area after a beat.
+         *
+         * @param {number} beatId - The beat ID this annotation follows
+         * @param {Object} pseudoBeat - The pseudo-beat object for the renderer
+         */
+        _renderInlineAnnotation(beatId, pseudoBeat) {
+            var chatArea = this.$refs.chatArea;
+            if (!chatArea || typeof ClawbackRenderer === "undefined") return;
+
+            // Find the beat element and insert the rendered annotation after it
+            var beatEl = chatArea.querySelector('[data-beat-id="' + beatId + '"].bubble');
+            if (!beatEl) return;
+
+            var el = ClawbackRenderer.renderBeat(pseudoBeat, chatArea);
+            if (el) {
+                // renderBeat appends to container end; detach then reinsert after the beat
+                if (el.parentNode) el.parentNode.removeChild(el);
+                beatEl.insertAdjacentElement("afterend", el);
+            }
+        },
+
+        /** Dismiss and remove the inline editor from the DOM. */
+        _dismissInlineEditor() {
+            if (this._inlineEditor && this._inlineEditor.element) {
+                this._inlineEditor.element.remove();
+            }
+            this._inlineEditor = null;
         },
 
         /** Jump playback to the start of a section. */

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -54,6 +54,38 @@ global.ANNOTATION_COLORS = ANNOTATION_COLORS;
 var saveCalls = 0;
 ClawbackAnnotations.save = function () { saveCalls++; return Promise.resolve(); };
 
+// Mock save to prevent actual HTTP calls
+var saveCalls = 0;
+ClawbackAnnotations.save = function () { saveCalls++; return Promise.resolve(); };
+
+// Minimal document mock for inline editor DOM creation
+global.document = {
+    createElement: function (tag) {
+        var el = {
+            tagName: tag.toUpperCase(),
+            className: "",
+            textContent: "",
+            type: "",
+            placeholder: "",
+            rows: 0,
+            value: "",
+            children: [],
+            style: {},
+            dataset: {},
+            _listeners: {},
+            appendChild: function (child) { el.children.push(child); },
+            insertAdjacentElement: function () {},
+            addEventListener: function (evt, fn) {
+                if (!el._listeners[evt]) el._listeners[evt] = [];
+                el._listeners[evt].push(fn);
+            },
+            focus: function () {},
+            remove: function () {},
+        };
+        return el;
+    },
+};
+
 const { clawbackApp } = require("../../../app/static/js/app.js");
 
 // ---------------------------------------------------------------------------
@@ -93,7 +125,13 @@ function makeBeats(n) {
 function makeApp(numBeats) {
     resetRendererCalls();
     const app = clawbackApp();
-    app.$refs = { chatArea: { innerHTML: "", parentElement: {} } };
+    app.$refs = {
+        chatArea: {
+            innerHTML: "",
+            parentElement: {},
+            querySelector: function () { return null; },
+        },
+    };
     if (numBeats !== undefined) {
         app.startPlayback(makeBeats(numBeats), "Test");
     }
@@ -1124,7 +1162,11 @@ function makeClickEvent(x, y, targetElement) {
         stopPropagation: function () { stopped = true; },
         get propagationStopped() { return stopped; },
         target: {
-            closest: function () { return targetElement || null; },
+            closest: function (sel) {
+                // .inline-editor should always return null for standard beat clicks
+                if (sel === ".inline-editor") return null;
+                return targetElement || null;
+            },
         },
     };
 }
@@ -1369,11 +1411,264 @@ test("Escape cancels pending section", function () {
     assert.equal(app._pendingSection, null);
 });
 
-test("Escape priority: form > pending > context menu > artifact", function () {
+// Inline annotation editors — callout and artifact creation
+// ---------------------------------------------------------------------------
+console.log("\ninline annotation editors — callout and artifact creation");
+
+/**
+ * Create a mock chat area with a querySelector that finds beat elements.
+ * Uses a simple registry of elements keyed by their beat ID selector.
+ */
+function makeMockChatArea() {
+    var children = [];
+    var area = {
+        innerHTML: "",
+        parentElement: {},
+        _elements: {},
+        querySelector: function (sel) {
+            // Match selectors like [data-beat-id="3"].bubble
+            var m = sel.match(/\[data-beat-id="(\d+)"\]\.(\w+)/);
+            if (m) {
+                var key = m[1] + "." + m[2];
+                return area._elements[key] || null;
+            }
+            return null;
+        },
+        appendChild: function (el) { children.push(el); },
+        get children() { return children; },
+    };
+    return area;
+}
+
+function addBeatToChatArea(chatArea, beatId, type) {
+    var inserted = [];
+    var el = {
+        dataset: { beatId: String(beatId) },
+        classList: { contains: function (cls) { return cls === type; } },
+        insertAdjacentElement: function (pos, child) { inserted.push({ pos: pos, child: child }); },
+        _inserted: inserted,
+    };
+    chatArea._elements[beatId + "." + type] = el;
+    return el;
+}
+
+test("_inlineEditor defaults to null", function () {
     const app = makeApp(5);
+    assert.equal(app._inlineEditor, null);
+});
+
+test("add-note action opens callout editor", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 2, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._contextMenu = { beatId: "2", isAnnotation: false, items: [], x: 0, y: 0 };
+    app.handleContextMenuAction("add-note");
+
+    assert.notEqual(app._inlineEditor, null);
+    assert.equal(app._inlineEditor.type, "callout");
+    assert.equal(app._inlineEditor.beatId, 2);
+    assert.equal(app._inlineEditor.style, "note");
+    assert.equal(app._contextMenu, null, "menu should be dismissed");
+});
+
+test("add-warning action opens warning editor", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 3, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._contextMenu = { beatId: "3", isAnnotation: false, items: [], x: 0, y: 0 };
+    app.handleContextMenuAction("add-warning");
+
+    assert.notEqual(app._inlineEditor, null);
+    assert.equal(app._inlineEditor.type, "callout");
+    assert.equal(app._inlineEditor.style, "warning");
+});
+
+test("attach-artifact action opens artifact editor", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 1, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._contextMenu = { beatId: "1", isAnnotation: false, items: [], x: 0, y: 0 };
+    app.handleContextMenuAction("attach-artifact");
+
+    assert.notEqual(app._inlineEditor, null);
+    assert.equal(app._inlineEditor.type, "artifact");
+    assert.equal(app._inlineEditor.beatId, 1);
+});
+
+test("callout editor has textarea and buttons", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._openCalloutEditor(0, "note");
+    assert.notEqual(app._inlineEditor.textarea, null);
+    assert.notEqual(app._inlineEditor.errorMsg, null);
+    assert.notEqual(app._inlineEditor.element, null);
+});
+
+test("artifact editor has title, desc, type, and content fields", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._openArtifactEditor(0);
+    assert.notEqual(app._inlineEditor.titleInput, null);
+    assert.notEqual(app._inlineEditor.descInput, null);
+    assert.notEqual(app._inlineEditor.typeSelect, null);
+    assert.notEqual(app._inlineEditor.textarea, null);
+});
+
+test("_dismissInlineEditor removes element and clears state", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._openCalloutEditor(0, "note");
+    assert.notEqual(app._inlineEditor, null);
+    app._dismissInlineEditor();
+    assert.equal(app._inlineEditor, null);
+});
+
+test("_saveCallout rejects empty content", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._openCalloutEditor(0, "note");
+    app._inlineEditor.textarea.value = "   ";
+    app._saveCallout();
+    assert.notEqual(app._inlineEditor, null, "editor should stay open");
+    assert.equal(app._inlineEditor.errorMsg.textContent, "Content cannot be empty");
+});
+
+test("_saveCallout creates annotation and dismisses editor", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    var beatEl = addBeatToChatArea(chatArea, 2, "bubble");
+    app.$refs.chatArea = chatArea;
+    saveCalls = 0;
+
+    // Reset annotations for clean test
+    ClawbackAnnotations.init({ sections: [], callouts: [], artifacts: [] });
+
+    app._openCalloutEditor(2, "warning");
+    app._inlineEditor.textarea.value = "Watch out!";
+    app._saveCallout();
+
+    assert.equal(app._inlineEditor, null, "editor should be dismissed");
+    var callouts = ClawbackAnnotations.getCallouts();
+    var found = callouts.find(function (c) { return c.content === "Watch out!"; });
+    assert.ok(found, "callout should exist");
+    assert.equal(found.style, "warning");
+    assert.equal(found.after_beat, 2);
+    assert.ok(saveCalls > 0, "save should be called");
+    // Verify rendered element was inserted after the beat
+    assert.equal(beatEl._inserted.length, 2, "form + annotation inserted");
+    assert.equal(beatEl._inserted[1].pos, "afterend", "annotation at afterend");
+});
+
+test("_saveArtifact rejects empty title", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._openArtifactEditor(0);
+    app._inlineEditor.titleInput.value = "";
+    app._inlineEditor.textarea.value = "some content";
+    app._saveArtifact();
+    assert.notEqual(app._inlineEditor, null, "editor should stay open");
+    assert.equal(app._inlineEditor.errorMsg.textContent, "Title cannot be empty");
+});
+
+test("_saveArtifact rejects empty content", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._openArtifactEditor(0);
+    app._inlineEditor.titleInput.value = "My Artifact";
+    app._inlineEditor.textarea.value = "   ";
+    app._saveArtifact();
+    assert.notEqual(app._inlineEditor, null, "editor should stay open");
+    assert.equal(app._inlineEditor.errorMsg.textContent, "Content cannot be empty");
+});
+
+test("_saveArtifact creates annotation and dismisses editor", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    var beatEl = addBeatToChatArea(chatArea, 3, "bubble");
+    app.$refs.chatArea = chatArea;
+    saveCalls = 0;
+
+    ClawbackAnnotations.init({ sections: [], callouts: [], artifacts: [] });
+
+    app._openArtifactEditor(3);
+    app._inlineEditor.titleInput.value = "Code Sample";
+    app._inlineEditor.descInput.value = "A description";
+    app._inlineEditor.typeSelect.value = "code";
+    app._inlineEditor.textarea.value = "console.log('hi');";
+    app._saveArtifact();
+
+    assert.equal(app._inlineEditor, null, "editor should be dismissed");
+    var artifacts = ClawbackAnnotations.getArtifacts();
+    var found = artifacts.find(function (a) { return a.title === "Code Sample"; });
+    assert.ok(found, "artifact should exist");
+    assert.equal(found.content_type, "code");
+    assert.equal(found.content, "console.log('hi');");
+    assert.equal(found.after_beat, 3);
+    assert.ok(saveCalls > 0, "save should be called");
+    // Verify rendered element was inserted after the beat
+    assert.equal(beatEl._inserted.length, 2, "form + annotation inserted");
+    assert.equal(beatEl._inserted[1].pos, "afterend", "annotation at afterend");
+});
+
+test("opening a new editor dismisses existing one", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    addBeatToChatArea(chatArea, 1, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._openCalloutEditor(0, "note");
+    assert.equal(app._inlineEditor.beatId, 0);
+    app._openCalloutEditor(1, "warning");
+    assert.equal(app._inlineEditor.beatId, 1, "should be new editor");
+});
+
+test("Escape dismisses inline editor", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._openCalloutEditor(0, "note");
+    assert.notEqual(app._inlineEditor, null);
+    app.handleKeydown(makeKeyEvent("Escape"));
+    assert.equal(app._inlineEditor, null);
+});
+
+test("Escape priority: form > pending > inline editor > context menu > artifact", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
     app.$refs.artifactPanelContent = { innerHTML: "" };
+
     app._sectionForm = { beatId: 0, label: "T", color: "blue" };
     app._pendingSection = { startBeat: 0, label: "T", color: "blue" };
+    app._openCalloutEditor(0, "note");
     app._contextMenu = { x: 0, y: 0, items: [], beatId: "0" };
     app.artifactOpen = true;
 
@@ -1383,10 +1678,14 @@ test("Escape priority: form > pending > context menu > artifact", function () {
 
     app.handleKeydown(makeKeyEvent("Escape"));
     assert.equal(app._pendingSection, null, "pending dismissed second");
+    assert.notEqual(app._inlineEditor, null, "inline editor still active");
+
+    app.handleKeydown(makeKeyEvent("Escape"));
+    assert.equal(app._inlineEditor, null, "inline editor dismissed third");
     assert.notEqual(app._contextMenu, null, "context menu still active");
 
     app.handleKeydown(makeKeyEvent("Escape"));
-    assert.equal(app._contextMenu, null, "context menu dismissed third");
+    assert.equal(app._contextMenu, null, "context menu dismissed fourth");
     assert.equal(app.artifactOpen, true, "artifact still open");
 
     app.handleKeydown(makeKeyEvent("Escape"));
@@ -1527,6 +1826,143 @@ test("palette includes all ANNOTATION_COLORS keys", function () {
     Object.keys(ANNOTATION_COLORS).forEach(function (k) {
         assert.ok(keys.indexOf(k) !== -1, "should include " + k);
     });
+});
+
+test("Escape works from TEXTAREA elements for editor dismissal", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._openCalloutEditor(0, "note");
+    var evt = makeKeyEvent("Escape", { target: { tagName: "TEXTAREA" } });
+    app.handleKeydown(evt);
+    assert.equal(app._inlineEditor, null, "editor should be dismissed from textarea");
+});
+
+test("backToSessions dismisses inline editor", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    app._openCalloutEditor(0, "note");
+    app.backToSessions();
+    assert.equal(app._inlineEditor, null);
+});
+
+test("clicking empty space in chat area dismisses inline editor", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+    app.editMode = true;
+
+    app._openCalloutEditor(0, "note");
+    // Click on empty space (no element match)
+    app.handleChatAreaClick(makeClickEvent(100, 100, null));
+    assert.equal(app._inlineEditor, null);
+});
+
+test("clicks inside inline editor do not trigger context menu", function () {
+    const app = makeApp(5);
+    app.editMode = true;
+    // Simulate click where closest(".inline-editor") returns truthy
+    var evt = {
+        clientX: 100,
+        clientY: 100,
+        stopPropagation: function () {},
+        target: {
+            closest: function (sel) {
+                if (sel === ".inline-editor") return {};
+                return null;
+            },
+        },
+    };
+    app.handleChatAreaClick(evt);
+    assert.equal(app._contextMenu, null, "no context menu should open");
+});
+
+test("callout multi-line content is preserved", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    ClawbackAnnotations.init({ sections: [], callouts: [], artifacts: [] });
+
+    app._openCalloutEditor(0, "note");
+    app._inlineEditor.textarea.value = "Line 1\nLine 2\nLine 3";
+    app._saveCallout();
+
+    var callouts = ClawbackAnnotations.getCallouts();
+    assert.equal(callouts[0].content, "Line 1\nLine 2\nLine 3");
+});
+
+test("artifact description is optional", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    ClawbackAnnotations.init({ sections: [], callouts: [], artifacts: [] });
+
+    app._openArtifactEditor(0);
+    app._inlineEditor.titleInput.value = "No Desc";
+    app._inlineEditor.descInput.value = "";
+    app._inlineEditor.textarea.value = "content here";
+    app._saveArtifact();
+
+    var artifacts = ClawbackAnnotations.getArtifacts();
+    var found = artifacts.find(function (a) { return a.title === "No Desc"; });
+    assert.ok(found, "artifact should be created");
+    assert.equal(found.description, "");
+});
+
+test("unique IDs are generated for callouts", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    ClawbackAnnotations.init({ sections: [], callouts: [], artifacts: [] });
+
+    app._openCalloutEditor(0, "note");
+    app._inlineEditor.textarea.value = "First";
+    app._saveCallout();
+
+    app._openCalloutEditor(0, "note");
+    app._inlineEditor.textarea.value = "Second";
+    app._saveCallout();
+
+    var callouts = ClawbackAnnotations.getCallouts();
+    assert.notEqual(callouts[0].id, callouts[1].id, "IDs should be unique");
+    assert.ok(callouts[0].id.startsWith("cal-"), "should have cal- prefix");
+    assert.ok(callouts[1].id.startsWith("cal-"), "should have cal- prefix");
+});
+
+test("unique IDs are generated for artifacts", function () {
+    const app = makeApp(5);
+    var chatArea = makeMockChatArea();
+    addBeatToChatArea(chatArea, 0, "bubble");
+    app.$refs.chatArea = chatArea;
+
+    ClawbackAnnotations.init({ sections: [], callouts: [], artifacts: [] });
+
+    app._openArtifactEditor(0);
+    app._inlineEditor.titleInput.value = "First";
+    app._inlineEditor.textarea.value = "content";
+    app._saveArtifact();
+
+    app._openArtifactEditor(0);
+    app._inlineEditor.titleInput.value = "Second";
+    app._inlineEditor.textarea.value = "content";
+    app._saveArtifact();
+
+    var artifacts = ClawbackAnnotations.getArtifacts();
+    assert.notEqual(artifacts[0].id, artifacts[1].id, "IDs should be unique");
+    assert.ok(artifacts[0].id.startsWith("art-"), "should have art- prefix");
+    assert.ok(artifacts[1].id.startsWith("art-"), "should have art- prefix");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Implements inline editors for creating note/warning callouts and embedded artifacts from the annotation context menu
- Editors appear below the target beat with textarea for callouts, full form (title, description, content type, content) for artifacts
- Includes validation (empty content/title rejected), auto-save with failure toast, Escape key handling across all form fields, and proper DOM positioning

## Changes

- **app.js** — Inline editor state (`_inlineEditor`), `_openCalloutEditor`, `_openArtifactEditor`, `_saveCallout`, `_saveArtifact`, `_renderInlineAnnotation` with detach-before-reinsert, `_dismissInlineEditor`, Escape priority restructure (editor > context menu > artifact), inline-editor click guard, action dispatch from context menu
- **style.css** — Inline editor styles with note/warning/artifact color variants, form elements, error messages, footer buttons
- **test_app.js** — 22 new tests, `document` mock for DOM creation, `ClawbackAnnotations.save` mock, selector-aware `makeClickEvent`, `makeMockChatArea`/`addBeatToChatArea` helpers, DOM position assertions

## Test plan

- [x] All 130 app.js tests pass
- [x] All 66 renderer tests pass
- [x] All 128 Python tests pass (324 total)
- [x] Code reviewer agent run — 4 issues found, all addressed

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)