### PR TITLE
feat(upload): add instructor session upload interface

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -223,6 +223,32 @@ body {
     font-weight: 500;
 }
 
+.picker__card--add {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border-style: dashed;
+    color: var(--color-text-muted);
+    min-height: 120px;
+}
+
+.picker__card--add:hover {
+    color: var(--color-accent);
+    transform: none;
+}
+
+.picker__add-icon {
+    font-size: 2rem;
+    line-height: 1;
+}
+
+.picker__add-label {
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
 .picker__empty {
     text-align: center;
     color: var(--color-text-muted);
@@ -296,6 +322,138 @@ body {
     height: 60vh;
     gap: 16px;
     color: var(--color-text-muted);
+}
+
+/* -----------------------------------------------------------------------
+   Upload form modal
+   ----------------------------------------------------------------------- */
+.upload-form-backdrop {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 50;
+}
+
+.upload-form {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    width: 380px;
+    max-width: 90vw;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    z-index: 51;
+}
+
+.upload-form__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px 12px;
+}
+
+.upload-form__title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.upload-form__close {
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    font-size: 1.25rem;
+    cursor: pointer;
+    padding: 0 4px;
+}
+
+.upload-form__close:hover {
+    color: var(--color-text);
+}
+
+.upload-form__body {
+    padding: 0 20px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.upload-form__file {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    word-break: break-all;
+}
+
+.upload-form__label {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+}
+
+.upload-form__input {
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font-family: inherit;
+    font-size: 0.9rem;
+    outline: none;
+    transition: border-color 0.15s;
+    width: 100%;
+}
+
+.upload-form__input:focus {
+    border-color: var(--color-accent);
+}
+
+.upload-form__error {
+    font-size: 0.85rem;
+    color: var(--color-accent);
+}
+
+.upload-form__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 0 20px 16px;
+}
+
+.upload-form__cancel,
+.upload-form__submit {
+    padding: 6px 16px;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.upload-form__cancel {
+    background: none;
+    border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+}
+
+.upload-form__cancel:hover {
+    color: var(--color-text);
+    border-color: var(--color-text-muted);
+}
+
+.upload-form__submit {
+    background-color: var(--color-accent);
+    border: 1px solid var(--color-accent);
+    color: #fff;
+}
+
+.upload-form__submit:hover:not(:disabled) {
+    background-color: var(--color-accent-hover);
+}
+
+.upload-form__submit:disabled {
+    opacity: 0.4;
+    cursor: default;
 }
 
 /* Spinner */

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -76,7 +76,7 @@
                 <!-- Session picker content -->
                 <div class="picker" x-show="!loadingSessions && !loadingSession">
                     <!-- Session grid -->
-                    <div class="picker__grid" x-show="sessions.length > 0">
+                    <div class="picker__grid">
                         <template x-for="session in sessions" :key="session.id">
                             <div class="picker__card" @click="loadSession(session)">
                                 <h3 class="picker__card-title" x-text="session.title"></h3>
@@ -84,11 +84,62 @@
                                 <span class="picker__card-meta" x-text="session.beat_count + ' beats'"></span>
                             </div>
                         </template>
+                        <!-- Add Session card -->
+                        <label class="picker__card picker__card--add">
+                            <span class="picker__add-icon">+</span>
+                            <span class="picker__add-label">Add Session</span>
+                            <input type="file" accept=".jsonl" @change="openUploadForm($event)" hidden>
+                        </label>
                     </div>
 
-                    <p class="picker__empty" x-show="sessions.length === 0">
-                        No curated sessions available.
-                    </p>
+                    <!-- Upload metadata form modal -->
+                    <template x-if="_uploadForm">
+                        <div class="upload-form-backdrop"
+                             x-transition.opacity.duration.200ms
+                             @click="cancelUpload()"></div>
+                    </template>
+                    <template x-if="_uploadForm">
+                        <div class="upload-form"
+                             x-transition
+                             x-init="$nextTick(() => $refs.uploadTitleInput && $refs.uploadTitleInput.focus())">
+                            <div class="upload-form__header">
+                                <h3 class="upload-form__title">Add Session</h3>
+                                <button class="upload-form__close" @click="cancelUpload()" title="Cancel">&times;</button>
+                            </div>
+                            <div class="upload-form__body">
+                                <p class="upload-form__file" x-text="_uploadForm.file.name"></p>
+                                <label class="upload-form__label">Title *</label>
+                                <input class="upload-form__input"
+                                       type="text"
+                                       x-model="_uploadForm.title"
+                                       placeholder="Session title"
+                                       x-ref="uploadTitleInput"
+                                       @keydown.enter="submitUpload()">
+                                <label class="upload-form__label">Description</label>
+                                <input class="upload-form__input"
+                                       type="text"
+                                       x-model="_uploadForm.description"
+                                       placeholder="Brief description (optional)"
+                                       @keydown.enter="submitUpload()">
+                                <label class="upload-form__label">Tags</label>
+                                <input class="upload-form__input"
+                                       type="text"
+                                       x-model="_uploadForm.tags"
+                                       placeholder="Comma-separated tags (optional)"
+                                       @keydown.enter="submitUpload()">
+                                <p class="upload-form__error" x-show="_uploadForm.error" x-text="_uploadForm.error"></p>
+                            </div>
+                            <div class="upload-form__footer">
+                                <button class="upload-form__cancel" @click="cancelUpload()">Cancel</button>
+                                <button class="upload-form__submit"
+                                        @click="submitUpload()"
+                                        :disabled="_uploadForm.uploading">
+                                    <span x-show="!_uploadForm.uploading">Upload</span>
+                                    <span x-show="_uploadForm.uploading">Uploading&#8230;</span>
+                                </button>
+                            </div>
+                        </div>
+                    </template>
 
                     <!-- Upload area -->
                     <div class="picker__upload">

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -32,6 +32,7 @@ function clawbackApp() {
         _pendingSection: null,
         _inlineEditor: null,
         _activeEditForm: null,
+        _uploadForm: null,
         _engine: null,
         _scroller: null,
         _conversationBeatsRendered: 0,
@@ -44,6 +45,12 @@ function clawbackApp() {
 
         /** Handle keyboard shortcuts (bound via @keydown.window on body). */
         handleKeydown(event) {
+            // Upload form Escape works in any view
+            if (event.code === "Escape" && this._uploadForm) {
+                this.cancelUpload();
+                return;
+            }
+
             if (this.view !== "playback") return;
 
             // Escape is always handled, even inside form inputs
@@ -154,6 +161,80 @@ function clawbackApp() {
                 self.uploadError = "Failed to read file.";
             };
             reader.readAsText(file);
+        },
+
+        // ---------------------------------------------------------------
+        // Server upload — "Add Session" flow
+        // ---------------------------------------------------------------
+
+        /**
+         * Open the upload form after the user selects a .jsonl file.
+         * Called by the hidden file input inside the "Add Session" card.
+         *
+         * @param {Event} event - File input change event
+         */
+        openUploadForm(event) {
+            var file = event.target.files[0];
+            if (!file) return;
+            // Pre-fill title from filename
+            var defaultTitle = file.name.replace(/\.jsonl$/, "").replace(/[-_]/g, " ");
+            this._uploadForm = {
+                file: file,
+                title: defaultTitle,
+                description: "",
+                tags: "",
+                error: "",
+                uploading: false,
+            };
+            // Reset input so the same file can be re-selected
+            event.target.value = "";
+        },
+
+        /** Cancel the upload form and discard the selected file. */
+        cancelUpload() {
+            this._uploadForm = null;
+        },
+
+        /** Submit the upload form to POST /api/sessions/upload. */
+        submitUpload() {
+            if (!this._uploadForm) return;
+            var title = this._uploadForm.title.trim();
+            if (!title) {
+                this._uploadForm.error = "Title is required";
+                return;
+            }
+            this._uploadForm.error = "";
+            this._uploadForm.uploading = true;
+
+            var formData = new FormData();
+            formData.append("file", this._uploadForm.file);
+            formData.append("title", title);
+            formData.append("description", this._uploadForm.description.trim());
+            formData.append("tags", this._uploadForm.tags.trim());
+
+            var self = this;
+            fetch("/api/sessions/upload", { method: "POST", body: formData })
+                .then(function (r) {
+                    return r.json().then(function (data) {
+                        return { ok: r.ok, data: data };
+                    });
+                })
+                .then(function (result) {
+                    if (!self._uploadForm) return;
+                    if (!result.ok) {
+                        self._uploadForm.uploading = false;
+                        self._uploadForm.error = result.data.message || "Upload failed";
+                        return;
+                    }
+                    // Add the new session to the picker grid
+                    self.sessions.push(result.data.session);
+                    self._uploadForm = null;
+                })
+                .catch(function () {
+                    if (!self._uploadForm) return;
+                    self._uploadForm.uploading = false;
+                    self._uploadForm.error = "Upload failed — check your connection";
+                });
         },
 
         /** Tear down the current engine and scroller. */

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -54,10 +54,6 @@ global.ANNOTATION_COLORS = ANNOTATION_COLORS;
 var saveCalls = 0;
 ClawbackAnnotations.save = function () { saveCalls++; return Promise.resolve(); };
 
-// Mock save to prevent actual HTTP calls
-var saveCalls = 0;
-ClawbackAnnotations.save = function () { saveCalls++; return Promise.resolve(); };
-
 // Minimal document mock for inline editor DOM creation
 global.document = {
     createElement: function (tag) {
@@ -2314,6 +2310,104 @@ test("transport buttons dismiss edit form", function () {
     app._openCalloutEditForm("callout-" + callout.id, callout);
     app.skipToEnd();
     assert.equal(app._activeEditForm, null, "skipToEnd should dismiss");
+});
+
+// ---------------------------------------------------------------------------
+// Upload form — openUploadForm, cancelUpload, submitUpload
+// ---------------------------------------------------------------------------
+console.log("\nUpload form");
+
+function makeFakeFile(name) {
+    return { name: name || "test-session.jsonl" };
+}
+
+function makeFileEvent(file) {
+    var cleared = false;
+    return {
+        target: {
+            files: [file],
+            get value() { return cleared ? "" : "C:\\fakepath\\" + file.name; },
+            set value(v) { cleared = (v === ""); },
+        },
+    };
+}
+
+test("openUploadForm sets _uploadForm state", function () {
+    var app = makeApp();
+    var file = makeFakeFile("my-session.jsonl");
+    app.openUploadForm(makeFileEvent(file));
+
+    assert.notEqual(app._uploadForm, null);
+    assert.equal(app._uploadForm.file, file);
+    assert.equal(app._uploadForm.title, "my session");
+    assert.equal(app._uploadForm.description, "");
+    assert.equal(app._uploadForm.tags, "");
+    assert.equal(app._uploadForm.error, "");
+    assert.equal(app._uploadForm.uploading, false);
+});
+
+test("openUploadForm strips .jsonl and replaces hyphens/underscores", function () {
+    var app = makeApp();
+    app.openUploadForm(makeFileEvent(makeFakeFile("cool_demo-session.jsonl")));
+    assert.equal(app._uploadForm.title, "cool demo session");
+});
+
+test("openUploadForm clears file input value", function () {
+    var app = makeApp();
+    var evt = makeFileEvent(makeFakeFile());
+    app.openUploadForm(evt);
+    assert.equal(evt.target.value, "");
+});
+
+test("openUploadForm no-ops when no file selected", function () {
+    var app = makeApp();
+    app.openUploadForm({ target: { files: [] } });
+    assert.equal(app._uploadForm, null);
+});
+
+test("cancelUpload resets _uploadForm to null", function () {
+    var app = makeApp();
+    app.openUploadForm(makeFileEvent(makeFakeFile()));
+    assert.notEqual(app._uploadForm, null);
+    app.cancelUpload();
+    assert.equal(app._uploadForm, null);
+});
+
+test("submitUpload rejects empty title", function () {
+    var app = makeApp();
+    app.openUploadForm(makeFileEvent(makeFakeFile()));
+    app._uploadForm.title = "   ";
+    app.submitUpload();
+    assert.notEqual(app._uploadForm, null, "form should stay open");
+    assert.equal(app._uploadForm.error, "Title is required");
+    assert.equal(app._uploadForm.uploading, false);
+});
+
+test("submitUpload no-ops when _uploadForm is null", function () {
+    var app = makeApp();
+    // Should not throw
+    app.submitUpload();
+});
+
+test("Escape dismisses upload form in picker view", function () {
+    var app = makeApp();
+    app.view = "picker";
+    app.openUploadForm(makeFileEvent(makeFakeFile()));
+    assert.notEqual(app._uploadForm, null);
+    app.handleKeydown(makeKeyEvent("Escape"));
+    assert.equal(app._uploadForm, null);
+});
+
+test("Escape in picker view is no-op when no upload form open", function () {
+    var app = makeApp();
+    app.view = "picker";
+    // Should not throw
+    app.handleKeydown(makeKeyEvent("Escape"));
+});
+
+test("_uploadForm defaults to null", function () {
+    var app = makeApp();
+    assert.equal(app._uploadForm, null);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add "Add Session" card to the session picker grid with dashed-border CTA styling
- Implement upload metadata form modal (title, description, tags) using Alpine.js `x-if` pattern for null-safe bindings
- Wire `openUploadForm()`, `cancelUpload()`, `submitUpload()` methods to POST file + metadata to `/api/sessions/upload`
- Add Escape key dismissal for upload form in picker view, null guards on async callbacks for cancel-during-upload race condition

## Test plan
- [x] 10 new unit tests covering `openUploadForm`, `cancelUpload`, `submitUpload`, Escape handling, edge cases
- [x] All 180 app.js tests pass (180/180)
- [x] All 413 JS tests pass across all test files
- [x] Code reviewer agent run — all 5 findings addressed
- [ ] Manual: upload a JSONL file via "Add Session", verify it appears in picker
- [ ] Manual: verify uploaded session is selectable and playable
- [ ] Manual: verify error states (empty title, invalid file, network error)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)