### PR TITLE
style(annotations): CSS custom properties and edge case polish

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -16,6 +16,18 @@
     --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
     --toolbar-height: 56px;
     --sidebar-width: 220px;
+
+    /* Annotation colors — used by callouts, inline editors, and section sidebar */
+    --color-annotation-note: #4A90D9;
+    --color-annotation-note-bg: rgba(74, 144, 217, 0.12);
+    --color-annotation-note-border: rgba(74, 144, 217, 0.3);
+    --color-annotation-warning: #F39C12;
+    --color-annotation-warning-bg: rgba(243, 156, 18, 0.12);
+    --color-annotation-warning-border: rgba(243, 156, 18, 0.3);
+    --color-annotation-artifact: #9B59B6;
+    --color-annotation-artifact-bg: rgba(155, 89, 182, 0.12);
+    --color-annotation-artifact-border: rgba(155, 89, 182, 0.3);
+    --color-annotation-error: #E74C3C;
 }
 
 /* Reset */
@@ -169,8 +181,8 @@ body {
 }
 
 .section-sidebar__delete:hover {
-    color: #E74C3C;
-    border-color: #E74C3C;
+    color: var(--color-annotation-error);
+    border-color: var(--color-annotation-error);
 }
 
 /* -----------------------------------------------------------------------
@@ -667,16 +679,18 @@ body {
     padding: 16px 20px;
     animation: fadeSlideUp 0.3s ease-out;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    overflow-wrap: break-word;
+    word-break: break-word;
 }
 
 .callout--note {
-    background-color: rgba(74, 144, 217, 0.12);
-    border: 1px solid rgba(74, 144, 217, 0.3);
+    background-color: var(--color-annotation-note-bg);
+    border: 1px solid var(--color-annotation-note-border);
 }
 
 .callout--warning {
-    background-color: rgba(243, 156, 18, 0.12);
-    border: 1px solid rgba(243, 156, 18, 0.3);
+    background-color: var(--color-annotation-warning-bg);
+    border: 1px solid var(--color-annotation-warning-border);
 }
 
 .callout__header {
@@ -699,11 +713,11 @@ body {
 }
 
 .callout--note .callout__title {
-    color: #4A90D9;
+    color: var(--color-annotation-note);
 }
 
 .callout--warning .callout__title {
-    color: #F39C12;
+    color: var(--color-annotation-warning);
 }
 
 .callout__content {
@@ -1322,15 +1336,15 @@ body {
 }
 
 .inline-editor--note {
-    border-left: 3px solid #5B9BD5;
+    border-left: 3px solid var(--color-annotation-note);
 }
 
 .inline-editor--warning {
-    border-left: 3px solid #E67E22;
+    border-left: 3px solid var(--color-annotation-warning);
 }
 
 .inline-editor--artifact {
-    border-left: 3px solid #9B59B6;
+    border-left: 3px solid var(--color-annotation-artifact);
 }
 
 .inline-editor__header {
@@ -1396,7 +1410,7 @@ body {
 }
 
 .inline-editor__error {
-    color: #E74C3C;
+    color: var(--color-annotation-error);
     font-size: 0.8rem;
     min-height: 1.2em;
     margin-top: 4px;

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1437,7 +1437,7 @@ function clawbackApp() {
             if (typeof ClawbackAnnotations !== "undefined") {
                 return ClawbackAnnotations.getColorHex(colorKey);
             }
-            return "#95A5A6";
+            return typeof ANNOTATION_COLORS !== "undefined" ? ANNOTATION_COLORS.slate : "#95A5A6";
         },
 
         /** Update the active section based on the current beat. */

--- a/tests/unit/js/test_annotations.js
+++ b/tests/unit/js/test_annotations.js
@@ -596,6 +596,54 @@ test("calling init again replaces all data", function () {
 });
 
 // ---------------------------------------------------------------------------
+// Edge case: beat ID bounds and empty arrays
+// ---------------------------------------------------------------------------
+console.log("\nedge case — beat ID bounds and empty arrays");
+
+test("getAnnotationsAfterBeat with negative beat ID returns empty array", function () {
+    var ann = freshAnnotations();
+    ann.init(makeSampleAnnotations(), "s1");
+    assert.deepStrictEqual(ann.getAnnotationsAfterBeat(-1), []);
+});
+
+test("getSectionForBeat with negative beat ID returns null", function () {
+    var ann = freshAnnotations();
+    ann.init(makeSampleAnnotations(), "s1");
+    assert.equal(ann.getSectionForBeat(-5), null);
+});
+
+test("getSectionForBeat with very large beat ID returns null", function () {
+    var ann = freshAnnotations();
+    ann.init(makeSampleAnnotations(), "s1");
+    assert.equal(ann.getSectionForBeat(99999), null);
+});
+
+test("init with explicitly empty arrays works correctly", function () {
+    var ann = freshAnnotations();
+    ann.init({ sections: [], callouts: [], artifacts: [] }, "s1");
+    assert.equal(ann.hasAnnotations(), false);
+    assert.equal(ann.hasSections(), false);
+    assert.deepStrictEqual(ann.getSections(), []);
+    assert.deepStrictEqual(ann.getAnnotationsAfterBeat(0), []);
+});
+
+test("init with empty object (no keys) works correctly", function () {
+    var ann = freshAnnotations();
+    ann.init({}, "s1");
+    assert.equal(ann.hasAnnotations(), false);
+    assert.equal(ann.hasSections(), false);
+    assert.deepStrictEqual(ann.getSections(), []);
+    assert.deepStrictEqual(ann.getCallouts(), []);
+    assert.deepStrictEqual(ann.getArtifacts(), []);
+});
+
+test("getAnnotationsAfterBeat with null afterBeatIndex returns empty array", function () {
+    var ann = freshAnnotations();
+    // Do not call init — leave _afterBeatIndex as null
+    assert.deepStrictEqual(ann.getAnnotationsAfterBeat(0), []);
+});
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
## Summary

- Extract all hard-coded annotation colors into CSS custom properties (`--color-annotation-*`) for theming compatibility
- Fix color inconsistency: inline editor note/warning borders now match callout title colors
- Add `overflow-wrap: break-word` to `.callout` for long text edge case
- Reference `ANNOTATION_COLORS.slate` constant instead of hard-coded `#95A5A6` fallback
- Add 6 edge case unit tests: negative/large beat IDs, empty arrays, null index guard

## Test plan

- [x] All 403 JS unit tests pass (58 annotations, 180 app, 66 renderer, 35 parser, 64 playback)
- [x] All 109 Python unit tests pass
- [x] All 51 Playwright integration tests pass
- [x] Code reviewer agent run — 2 findings addressed
- [x] All 14 AC items verified against codebase

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)