### PR TITLE
feat(playback): skip collapsed inner workings groups on arrow navigation (#81)

### DIFF
--- a/app/static/js/playback.js
+++ b/app/static/js/playback.js
@@ -79,7 +79,8 @@ class PlaybackEngine {
         this._pauseInternal(PlaybackState.SCROLL_PAUSED);
     }
 
-    /** Immediately advance to the next beat. */
+    /** Immediately advance to the next beat.
+     *  When inner workings are collapsed, skips the entire group in one step. */
     next() {
         if (this.currentIndex >= this.beats.length) return;
         if (this.state === PlaybackState.COMPLETE) return;
@@ -87,17 +88,34 @@ class PlaybackEngine {
         this._clearTimer();
         this._remainingFraction = null;
 
-        const beatIndex = this.currentIndex;
+        var beatIndex = this.currentIndex;
         this._renderCurrentBeat();
+
+        // Skip remaining beats in a collapsed inner workings group
+        if (this.innerWorkingsMode === "collapsed") {
+            var renderedBeat = this.beats[beatIndex];
+            if (renderedBeat.category === "inner_working" && renderedBeat.group_id != null) {
+                while (this.currentIndex < this.beats.length) {
+                    var nextBeat = this.beats[this.currentIndex];
+                    if (nextBeat.group_id !== renderedBeat.group_id ||
+                        nextBeat.category !== "inner_working") break;
+                    this._renderCurrentBeat();
+                }
+            }
+        }
+
+        // Use last-rendered index for rescheduling (not the first in a skipped group)
+        var lastRenderedIndex = this.currentIndex - 1;
 
         if (this.currentIndex >= this.beats.length) {
             this._setState(PlaybackState.COMPLETE);
         } else if (this.state === PlaybackState.PLAYING) {
-            this._scheduleWait(beatIndex, 1.0);
+            this._scheduleWait(lastRenderedIndex, 1.0);
         }
     }
 
-    /** Remove the last rendered beat. */
+    /** Remove the last rendered beat.
+     *  When inner workings are collapsed, removes the entire group in one step. */
     previous() {
         if (this.currentIndex <= 0) return;
 
@@ -110,6 +128,20 @@ class PlaybackEngine {
         const beat = this.beats[this.currentIndex];
         if (this.onRemoveBeat) {
             this.onRemoveBeat(beat);
+        }
+
+        // Skip remaining beats in a collapsed inner workings group
+        if (this.innerWorkingsMode === "collapsed" &&
+            beat.category === "inner_working" && beat.group_id != null) {
+            while (this.currentIndex > 0) {
+                var prevBeat = this.beats[this.currentIndex - 1];
+                if (prevBeat.group_id !== beat.group_id ||
+                    prevBeat.category !== "inner_working") break;
+                this.currentIndex--;
+                if (this.onRemoveBeat) {
+                    this.onRemoveBeat(prevBeat);
+                }
+            }
         }
 
         if (

--- a/tests/unit/js/test_playback.js
+++ b/tests/unit/js/test_playback.js
@@ -843,6 +843,203 @@ test("pauses playback when jumping during PLAYING", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Collapsed inner workings group skipping
+// ---------------------------------------------------------------------------
+console.log("\nCollapsed inner workings group skipping");
+
+test("next skips entire collapsed inner workings group", () => {
+    var rendered = [];
+    var beats = [
+        makeBeat(0, { type: "user_message" }),
+        makeInnerBeat(1, { type: "thinking", group_id: 1 }),
+        makeInnerBeat(2, { type: "tool_call", group_id: 1 }),
+        makeInnerBeat(3, { type: "tool_result", group_id: 1 }),
+        makeBeat(4, { type: "assistant_message" }),
+    ];
+    var engine = new PlaybackEngine({
+        beats: beats,
+        onBeat: function (beat) { rendered.push(beat.id); },
+    });
+    engine.innerWorkingsMode = "collapsed";
+
+    engine.next(); // renders beat 0 (user)
+    assert.deepEqual(rendered, [0]);
+    assert.equal(engine.currentIndex, 1);
+
+    engine.next(); // should render beats 1, 2, 3 (entire group)
+    assert.deepEqual(rendered, [0, 1, 2, 3]);
+    assert.equal(engine.currentIndex, 4);
+});
+
+test("next does not skip when expanded", () => {
+    var rendered = [];
+    var beats = [
+        makeBeat(0, { type: "user_message" }),
+        makeInnerBeat(1, { type: "thinking", group_id: 1 }),
+        makeInnerBeat(2, { type: "tool_call", group_id: 1 }),
+        makeBeat(3, { type: "assistant_message" }),
+    ];
+    var engine = new PlaybackEngine({
+        beats: beats,
+        onBeat: function (beat) { rendered.push(beat.id); },
+    });
+    engine.innerWorkingsMode = "expanded";
+
+    engine.next();
+    assert.deepEqual(rendered, [0]);
+    engine.next();
+    assert.deepEqual(rendered, [0, 1]);
+    assert.equal(engine.currentIndex, 2);
+});
+
+test("previous skips entire collapsed inner workings group", () => {
+    var removed = [];
+    var beats = [
+        makeBeat(0, { type: "user_message" }),
+        makeInnerBeat(1, { type: "thinking", group_id: 1 }),
+        makeInnerBeat(2, { type: "tool_call", group_id: 1 }),
+        makeInnerBeat(3, { type: "tool_result", group_id: 1 }),
+        makeBeat(4, { type: "assistant_message" }),
+    ];
+    var engine = new PlaybackEngine({
+        beats: beats,
+        onRemoveBeat: function (beat) { removed.push(beat.id); },
+    });
+    engine.currentIndex = 5; // all rendered
+    engine.innerWorkingsMode = "collapsed";
+
+    engine.previous(); // removes beat 4 (assistant)
+    assert.deepEqual(removed, [4]);
+    assert.equal(engine.currentIndex, 4);
+
+    engine.previous(); // should remove beats 3, 2, 1 (entire group)
+    assert.deepEqual(removed, [4, 3, 2, 1]);
+    assert.equal(engine.currentIndex, 1);
+});
+
+test("previous does not skip when expanded", () => {
+    var removed = [];
+    var beats = [
+        makeBeat(0, { type: "user_message" }),
+        makeInnerBeat(1, { type: "thinking", group_id: 1 }),
+        makeInnerBeat(2, { type: "tool_call", group_id: 1 }),
+        makeBeat(3, { type: "assistant_message" }),
+    ];
+    var engine = new PlaybackEngine({
+        beats: beats,
+        onRemoveBeat: function (beat) { removed.push(beat.id); },
+    });
+    engine.currentIndex = 4;
+    engine.innerWorkingsMode = "expanded";
+
+    engine.previous();
+    assert.deepEqual(removed, [3]);
+    engine.previous();
+    assert.deepEqual(removed, [3, 2]);
+    assert.equal(engine.currentIndex, 2);
+});
+
+test("next skips group at end of beats", () => {
+    var rendered = [];
+    var beats = [
+        makeBeat(0, { type: "user_message" }),
+        makeInnerBeat(1, { type: "thinking", group_id: 1 }),
+        makeInnerBeat(2, { type: "tool_call", group_id: 1 }),
+    ];
+    var engine = new PlaybackEngine({
+        beats: beats,
+        onBeat: function (beat) { rendered.push(beat.id); },
+    });
+    engine.innerWorkingsMode = "collapsed";
+
+    engine.next(); // user
+    engine.next(); // should render entire group and reach COMPLETE
+    assert.deepEqual(rendered, [0, 1, 2]);
+    assert.equal(engine.currentIndex, 3);
+    assert.equal(engine.state, PlaybackState.COMPLETE);
+});
+
+test("previous skips group at start of beats", () => {
+    var removed = [];
+    var beats = [
+        makeInnerBeat(0, { type: "thinking", group_id: 1 }),
+        makeInnerBeat(1, { type: "tool_call", group_id: 1 }),
+        makeBeat(2, { type: "assistant_message" }),
+    ];
+    var engine = new PlaybackEngine({
+        beats: beats,
+        onRemoveBeat: function (beat) { removed.push(beat.id); },
+    });
+    engine.currentIndex = 3;
+    engine.innerWorkingsMode = "collapsed";
+
+    engine.previous(); // removes assistant
+    engine.previous(); // should remove entire group
+    assert.deepEqual(removed, [2, 1, 0]);
+    assert.equal(engine.currentIndex, 0);
+});
+
+test("next handles consecutive groups", () => {
+    var rendered = [];
+    var beats = [
+        makeBeat(0, { type: "user_message" }),
+        makeInnerBeat(1, { type: "thinking", group_id: 1 }),
+        makeInnerBeat(2, { type: "tool_call", group_id: 1 }),
+        makeInnerBeat(3, { type: "thinking", group_id: 2 }),
+        makeInnerBeat(4, { type: "tool_call", group_id: 2 }),
+        makeBeat(5, { type: "assistant_message" }),
+    ];
+    var engine = new PlaybackEngine({
+        beats: beats,
+        onBeat: function (beat) { rendered.push(beat.id); },
+    });
+    engine.innerWorkingsMode = "collapsed";
+
+    engine.next(); // user
+    assert.deepEqual(rendered, [0]);
+
+    engine.next(); // group 1
+    assert.deepEqual(rendered, [0, 1, 2]);
+    assert.equal(engine.currentIndex, 3);
+
+    engine.next(); // group 2
+    assert.deepEqual(rendered, [0, 1, 2, 3, 4]);
+    assert.equal(engine.currentIndex, 5);
+
+    engine.next(); // assistant
+    assert.deepEqual(rendered, [0, 1, 2, 3, 4, 5]);
+});
+
+test("next skips mid-group remainder when switching to collapsed", () => {
+    var rendered = [];
+    var beats = [
+        makeBeat(0, { type: "user_message" }),
+        makeInnerBeat(1, { type: "thinking", group_id: 1 }),
+        makeInnerBeat(2, { type: "tool_call", group_id: 1 }),
+        makeInnerBeat(3, { type: "tool_result", group_id: 1 }),
+        makeInnerBeat(4, { type: "tool_call", group_id: 1 }),
+        makeBeat(5, { type: "assistant_message" }),
+    ];
+    var engine = new PlaybackEngine({
+        beats: beats,
+        onBeat: function (beat) { rendered.push(beat.id); },
+    });
+    engine.innerWorkingsMode = "expanded";
+
+    engine.next(); // user
+    engine.next(); // thinking (expanded, one at a time)
+    engine.next(); // tool_call
+    assert.deepEqual(rendered, [0, 1, 2]);
+    assert.equal(engine.currentIndex, 3);
+
+    // Switch to collapsed mid-group
+    engine.innerWorkingsMode = "collapsed";
+    engine.next(); // should render beats 3 and 4 (remainder of group)
+    assert.deepEqual(rendered, [0, 1, 2, 3, 4]);
+    assert.equal(engine.currentIndex, 5);
+});
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
## Summary
- Right arrow on a collapsed inner workings group now renders the entire group in one keypress
- Left arrow stepping back into a collapsed group removes the entire group in one keypress
- Navigation is unchanged when inner workings are expanded

## Changes
- `app/static/js/playback.js` — Modified `next()` and `previous()` to consume/remove entire collapsed groups
- `tests/unit/js/test_playback.js` — 8 new tests covering all skip scenarios

## Test Results
- 180/180 JS tests pass (72 playback, 8 new)
- 109/109 Python tests pass

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)