### PR TITLE
fix(ui): open markdown links in new tab and preserve user message whitespace

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -514,6 +514,7 @@ body {
     align-self: flex-end;
     background-color: var(--color-user-bubble);
     border-bottom-right-radius: 4px;
+    white-space: pre-wrap;
 }
 
 /* Assistant bubble — left-aligned, bordered */

--- a/app/static/js/renderer.js
+++ b/app/static/js/renderer.js
@@ -9,6 +9,20 @@
  * parser's group_id into collapsible summary cards.
  */
 
+// Configure marked to open all links in a new tab
+marked.use({
+    renderer: {
+        link: function (args) {
+            var href = /^javascript:/i.test(args.href) ? "#" : args.href;
+            var label = (args.tokens && args.tokens.length)
+                ? this.parser.parseInline(args.tokens)
+                : (args.text || href);
+            return '<a href="' + href + '" target="_blank" rel="noopener noreferrer">'
+                + label + '</a>';
+        },
+    },
+});
+
 /** @type {Map<number, Object>} Active inner workings groups by group_id */
 const _activeGroups = new Map();
 

--- a/tests/unit/js/test_renderer.js
+++ b/tests/unit/js/test_renderer.js
@@ -83,6 +83,7 @@ global.marked = {
         markedCalls.push(text);
         return `<p>${text}</p>`;
     },
+    use: () => {},
 };
 
 let hljsCalls = [];


### PR DESCRIPTION
## Summary

- Configure marked.js with a custom link renderer to open all links in new tabs (`target="_blank"`, `rel="noopener noreferrer"`)
- Add defensive `javascript:` href sanitization and proper inline token parsing via `this.parser.parseInline()`
- Preserve intentional linebreaks in user message bubbles with `white-space: pre-wrap`

## Changes

- **`app/static/js/renderer.js`** — Added `marked.use()` with custom link renderer at module load
- **`app/static/css/style.css`** — Added `white-space: pre-wrap` to `.bubble--user`
- **`tests/unit/js/test_renderer.js`** — Added `use: () => {}` to global marked mock

## Test Results

- 180 JS tests passed
- 109 Python tests passed

Closes #85, Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)