### PR TITLE
feat(ui): add hero card to session picker screen

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -194,6 +194,46 @@ body {
     padding: 48px 0;
 }
 
+.hero {
+    margin-bottom: 32px;
+    padding: 24px 28px;
+    background-color: var(--color-surface);
+    border-top: 1px solid var(--color-border);
+    border-right: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
+    border-left: 4px solid var(--color-accent);
+    border-radius: 12px;
+}
+
+.hero__tagline {
+    font-size: 1rem;
+    color: var(--color-text-muted);
+    margin-bottom: 16px;
+}
+
+.hero__actions {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+}
+
+.hero__actions strong {
+    color: var(--color-text);
+}
+
+.hero__actions code {
+    font-family: var(--font-mono);
+    background-color: rgba(0, 0, 0, 0.3);
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-size: 0.85em;
+}
+
 .picker__grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -75,6 +75,15 @@
 
                 <!-- Session picker content -->
                 <div class="picker" x-show="!loadingSessions && !loadingSession">
+                    <!-- Hero card -->
+                    <div class="hero">
+                        <p class="hero__tagline">Watch how AI-assisted development actually works.</p>
+                        <ul class="hero__actions" role="list">
+                            <li><strong>Play a curated session</strong> &mdash; pick one below to see a real context engineering workflow</li>
+                            <li><strong>Upload your own</strong> &mdash; drop a Claude Code <code>.jsonl</code> file to replay any session</li>
+                        </ul>
+                    </div>
+
                     <!-- Session grid -->
                     <div class="picker__grid">
                         <template x-for="session in sessions" :key="session.id">

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -88,6 +88,9 @@ def test_index_has_session_picker(client):
     assert "backToSessions" in html, "back button must be present"
     assert "handleFileUpload" in html, "file upload handler must be present"
     assert "handleFileDrop" in html, "drag-and-drop handler must be present"
+    # Hero card
+    assert 'class="hero"' in html, "hero card must be present"
+    assert "curated session" in html.lower(), "hero must mention curated sessions"
 
 
 def test_index_has_keyboard_shortcut_binding(client):


### PR DESCRIPTION
## Summary

- Add a hero card at the top of the session picker to orient new users
- Tagline + bullet points explaining curated sessions and file upload
- Accent left border, accessible list semantics (`role="list"`)

## Changes

- **`app/static/index.html`** — Hero card HTML in picker view
- **`app/static/css/style.css`** — `.hero` styles with accent border
- **`tests/unit/test_views.py`** — Hero card assertions

## Test Results

- 188 JS tests passed
- 109 Python tests passed

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)