### PR TITLE
feat(ui): highlight active section in sections blade

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -135,7 +135,7 @@ body {
     flex-direction: column;
     gap: 2px;
     padding: 10px 16px;
-    border-left: 3px solid transparent;
+    border-left: 3px solid var(--section-color, transparent);
     cursor: pointer;
     transition: background-color 0.15s, border-left-color 0.15s;
     position: relative;
@@ -147,12 +147,19 @@ body {
 
 .section-sidebar__item--active {
     background-color: rgba(255, 255, 255, 0.08);
+    border-left-width: 4px;
+    padding-left: 15px;
+}
+
+.section-sidebar__item--active .section-sidebar__label {
+    color: var(--section-color);
 }
 
 .section-sidebar__label {
     font-size: 0.875rem;
     font-weight: 500;
     color: var(--color-text);
+    transition: color 0.15s;
 }
 
 .section-sidebar__range {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -45,7 +45,7 @@
                     <div class="section-sidebar__item"
                          :class="{ 'section-sidebar__item--active': activeSection && activeSection.id === section.id }"
                          @click="jumpToSection(section)"
-                         :style="'border-left-color:' + getSectionColor(section.color)">
+                         :style="'--section-color:' + getSectionColor(section.color)">
                         <span class="section-sidebar__label" x-text="section.label"></span>
                         <span class="section-sidebar__range"
                               x-text="'Beats ' + (section.start_beat + 1) + '\u2013' + (section.end_beat + 1)"></span>


### PR DESCRIPTION
## Summary

- Active section label text colors to match its assigned section color
- Left border thickens from 3px to 4px with 1px padding compensation (no layout shift)
- Refactored inline style to CSS custom property `--section-color` for clean cascading
- Smooth transitions on both color and border changes

## Changes

- **`app/static/index.html`** — Changed inline style from `border-left-color:` to `--section-color:` custom property
- **`app/static/css/style.css`** — Updated section item styles to use `var(--section-color)`, added active label coloring and padding offset

## Test Results

- 188 JS tests passed
- 109 Python tests passed

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)