### PR TITLE
feat(ui): add coachmark tutorial with spotlight overlay

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1692,3 +1692,107 @@ body {
     color: var(--color-text);
     border-color: var(--color-text-muted);
 }
+
+/* -----------------------------------------------------------------------
+   Coachmark tour
+   ----------------------------------------------------------------------- */
+.toolbar__btn--help {
+    font-weight: 700;
+    font-size: 0.9rem;
+    min-width: 28px;
+}
+
+.toolbar__btn--glow {
+    animation: help-glow 2s ease-in-out infinite;
+}
+
+@keyframes help-glow {
+    0%, 100% { box-shadow: 0 0 4px rgba(233, 69, 96, 0.3); }
+    50% { box-shadow: 0 0 12px rgba(233, 69, 96, 0.7), 0 0 24px rgba(233, 69, 96, 0.3); }
+}
+
+.tour-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.6);
+    z-index: 100;
+}
+
+.tour-spotlight {
+    position: fixed;
+    border-radius: 8px;
+    box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.6);
+    background-color: transparent;
+    z-index: 101;
+    pointer-events: none;
+    transition: left 0.3s, top 0.3s, width 0.3s, height 0.3s;
+}
+
+.tour-tooltip {
+    position: fixed;
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    padding: 16px 20px;
+    max-width: 320px;
+    z-index: 102;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+
+.tour-tooltip__title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--color-accent);
+    margin-bottom: 6px;
+}
+
+.tour-tooltip__text {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+    margin-bottom: 14px;
+}
+
+.tour-tooltip__nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.tour-tooltip__dots {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+}
+
+.tour-tooltip__btn {
+    padding: 5px 14px;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    font-family: inherit;
+    background: none;
+    border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+}
+
+.tour-tooltip__btn:hover:not(:disabled) {
+    color: var(--color-text);
+    border-color: var(--color-text-muted);
+}
+
+.tour-tooltip__btn:disabled {
+    opacity: 0.3;
+    cursor: default;
+}
+
+.tour-tooltip__btn--primary {
+    background-color: var(--color-accent);
+    border-color: var(--color-accent);
+    color: #fff;
+}
+
+.tour-tooltip__btn--primary:hover:not(:disabled) {
+    background-color: var(--color-accent-hover);
+    color: #fff;
+}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -230,6 +230,16 @@
 
         <div class="toolbar__separator"></div>
 
+        <!-- Tour help button -->
+        <div class="toolbar__group">
+            <button class="toolbar__btn toolbar__btn--help"
+                    :class="{ 'toolbar__btn--glow': _tourShowGlow }"
+                    @click="startTour()"
+                    title="Take a tour">?</button>
+        </div>
+
+        <div class="toolbar__separator"></div>
+
         <!-- Progress bar and beat counter -->
         <div class="toolbar__group toolbar__group--progress">
             <div class="toolbar__bar">
@@ -337,6 +347,46 @@
          x-transition
          x-cloak
          x-text="editToast"></div>
+
+    <!-- Coachmark tour overlay -->
+    <template x-if="tourActive">
+        <div class="tour-overlay" @click="endTour()">
+            <div class="tour-spotlight"
+                 x-effect="$el.style.cssText = (function(r) {
+                     if (!r) return 'display:none';
+                     var p = 8;
+                     return 'left:' + (r.left - p) + 'px;top:' + (r.top - p) + 'px;width:' + (r.width + p*2) + 'px;height:' + (r.height + p*2) + 'px';
+                 })(getTourRect())"></div>
+            <div class="tour-tooltip" @click.stop
+                 x-effect="(function(r, step) {
+                     if (!r || !step) return;
+                     var tt = $el;
+                     var p = step.position;
+                     var cx = r.left + r.width / 2;
+                     var vw = window.innerWidth;
+                     var vh = window.innerHeight;
+                     var tw = Math.min(tt.offsetWidth || 320, 320);
+                     var left = Math.max(16 + tw / 2, Math.min(cx, vw - tw / 2 - 16));
+                     tt.style.left = left + 'px';
+                     if (p === 'top') {
+                         tt.style.top = Math.max(16, r.top - 16) + 'px';
+                         tt.style.transform = 'translate(-50%, -100%)';
+                     } else {
+                         tt.style.top = Math.min(vh - 16, r.bottom + 16) + 'px';
+                         tt.style.transform = 'translate(-50%, 0)';
+                     }
+                 })(_tourRect, getCurrentTourStep())">
+                <div class="tour-tooltip__title" x-text="getCurrentTourStep() ? getCurrentTourStep().title : ''"></div>
+                <div class="tour-tooltip__text" x-text="getCurrentTourStep() ? getCurrentTourStep().text : ''"></div>
+                <div class="tour-tooltip__nav">
+                    <button class="tour-tooltip__btn" @click="tourPrev()" :disabled="tourStep === 0">Back</button>
+                    <span class="tour-tooltip__dots" x-text="(tourStep + 1) + ' / ' + _tourSteps.length"></span>
+                    <button class="tour-tooltip__btn tour-tooltip__btn--primary" @click="tourNext()"
+                            x-text="tourStep === _tourSteps.length - 1 ? 'Done' : 'Next'"></button>
+                </div>
+            </div>
+        </div>
+    </template>
 
     <!-- Scroll-pause indicator -->
     <div class="scroll-pause-indicator"

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -37,6 +37,18 @@ function clawbackApp() {
         _scroller: null,
         _conversationBeatsRendered: 0,
         _beatIdToMergedIndex: null,
+        tourActive: false,
+        tourStep: 0,
+        _tourSteps: [
+            { target: ".toolbar__group:first-child", title: "Transport Controls", text: "Play, pause, skip forward/back, and jump to start or end. These control the beat-by-beat playback of the session.", position: "top" },
+            { target: ".speed-stepper", title: "Speed Control", text: "Adjust playback speed from 0.5x to 4.0x. Slower speeds give you time to read dense content; faster speeds let you skim.", position: "top" },
+            { target: ".toolbar__label", title: "Inner Workings", text: "Toggle between Collapsed and Expanded to show or hide the AI's thinking, tool calls, and tool results. Collapsed gives a clean chat view.", position: "top" },
+            { target: ".chat-area", title: "Chat Area", text: "Messages appear here as the session plays back. User messages are on the right, assistant messages on the left. Click any beat in edit mode to add annotations.", position: "bottom" },
+            { target: ".toolbar__group--progress", title: "Progress Bar", text: "Shows your position in the session. The colored segments represent sections defined by the instructor. The beat counter shows your exact position.", position: "top" },
+        ],
+        _tourShowGlow: false,
+        _tourRect: null,
+        _tourResizeHandler: null,
 
         /** Called by Alpine.js on component initialization. */
         init() {
@@ -55,7 +67,9 @@ function clawbackApp() {
 
             // Escape is always handled, even inside form inputs
             if (event.code === "Escape") {
-                if (this._activeEditForm) {
+                if (this.tourActive) {
+                    this.endTour();
+                } else if (this._activeEditForm) {
                     this._dismissEditForm();
                 } else if (this._sectionForm) {
                     this.cancelSectionForm();
@@ -310,6 +324,8 @@ function clawbackApp() {
                 this.progressSegments = [{ width: 100, color: null }];
             }
 
+            this._initTourGlow();
+
             // Build merged beat array with callout pseudo-beats interleaved
             var merged = this._buildMergedBeats(beats);
 
@@ -380,6 +396,7 @@ function clawbackApp() {
 
         /** Toggle between play and pause. */
         togglePlay() {
+            this._dismissGlow();
             if (!this._engine) return;
             if (this.playbackState === "PLAYING") {
                 this._engine.pause();
@@ -457,6 +474,82 @@ function clawbackApp() {
         /** Toggle section sidebar visibility. */
         toggleSections() {
             this.showSections = !this.showSections;
+        },
+
+        /** Start the coachmark tour. */
+        startTour() {
+            this._tourShowGlow = false;
+            // Close competing overlays before opening tour
+            if (this.artifactOpen) this.closeArtifact();
+            if (this._contextMenu) this.dismissContextMenu();
+            // Remove stale resize listener before re-registering
+            if (this._tourResizeHandler) {
+                window.removeEventListener("resize", this._tourResizeHandler);
+            }
+            this.tourStep = 0;
+            this.tourActive = true;
+            try { localStorage.setItem("clawback_toured", "1"); } catch (e) { /* noop */ }
+            // Reposition spotlight on window resize
+            this._tourResizeHandler = function () { this.getTourRect(); }.bind(this);
+            window.addEventListener("resize", this._tourResizeHandler);
+        },
+
+        /** Advance to the next tour step, or end the tour. */
+        tourNext() {
+            if (this.tourStep < this._tourSteps.length - 1) {
+                this.tourStep++;
+            } else {
+                this.endTour();
+            }
+        },
+
+        /** Go back to the previous tour step. */
+        tourPrev() {
+            if (this.tourStep > 0) {
+                this.tourStep--;
+            }
+        },
+
+        /** End the tour. */
+        endTour() {
+            this.tourActive = false;
+            if (this._tourResizeHandler) {
+                window.removeEventListener("resize", this._tourResizeHandler);
+                this._tourResizeHandler = null;
+            }
+        },
+
+        /** Get the bounding rect for the current tour step's target element. */
+        getTourRect() {
+            if (!this.tourActive) { this._tourRect = null; return null; }
+            var step = this._tourSteps[this.tourStep];
+            var el = document.querySelector(step.target);
+            if (!el) { this._tourRect = null; return null; }
+            var r = el.getBoundingClientRect();
+            this._tourRect = r;
+            return r;
+        },
+
+        /** Get the current tour step definition. */
+        getCurrentTourStep() {
+            if (!this.tourActive) return null;
+            return this._tourSteps[this.tourStep];
+        },
+
+        /** Check localStorage to show glow for first-time visitors. */
+        _initTourGlow() {
+            try {
+                if (!localStorage.getItem("clawback_toured")) {
+                    this._tourShowGlow = true;
+                }
+            } catch (e) {
+                this._tourShowGlow = false;
+            }
+        },
+
+        /** Dismiss the glow when user interacts with controls. */
+        _dismissGlow() {
+            this._tourShowGlow = false;
         },
 
         /** Open the artifact panel and pause playback. Disabled in edit mode. */

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -80,6 +80,32 @@ global.document = {
         };
         return el;
     },
+    querySelector: function () { return null; },
+};
+
+// window mock for resize event handling
+var _windowListeners = {};
+global.window = {
+    innerWidth: 1280,
+    innerHeight: 800,
+    addEventListener: function (evt, fn) {
+        if (!_windowListeners[evt]) _windowListeners[evt] = [];
+        _windowListeners[evt].push(fn);
+    },
+    removeEventListener: function (evt, fn) {
+        if (_windowListeners[evt]) {
+            _windowListeners[evt] = _windowListeners[evt].filter(function (f) { return f !== fn; });
+        }
+    },
+};
+
+// localStorage mock
+var _lsStore = {};
+global.localStorage = {
+    getItem: function (k) { return _lsStore[k] || null; },
+    setItem: function (k, v) { _lsStore[k] = String(v); },
+    removeItem: function (k) { delete _lsStore[k]; },
+    clear: function () { _lsStore = {}; },
 };
 
 const { clawbackApp } = require("../../../app/static/js/app.js");
@@ -2473,6 +2499,157 @@ test("Escape in picker view is no-op when no upload form open", function () {
 test("_uploadForm defaults to null", function () {
     var app = makeApp();
     assert.equal(app._uploadForm, null);
+});
+
+// ---------------------------------------------------------------------------
+// Tour (coachmarks)
+// ---------------------------------------------------------------------------
+console.log("\nTour");
+
+test("startTour sets tourActive and tourStep", function () {
+    var app = makeApp(5);
+    app.startTour();
+    assert.equal(app.tourActive, true);
+    assert.equal(app.tourStep, 0);
+});
+
+test("tourNext advances step", function () {
+    var app = makeApp(5);
+    app.startTour();
+    app.tourNext();
+    assert.equal(app.tourStep, 1);
+});
+
+test("tourNext on last step ends tour", function () {
+    var app = makeApp(5);
+    app.startTour();
+    app.tourStep = app._tourSteps.length - 1;
+    app.tourNext();
+    assert.equal(app.tourActive, false);
+});
+
+test("tourPrev goes back", function () {
+    var app = makeApp(5);
+    app.startTour();
+    app.tourNext();
+    app.tourNext();
+    app.tourPrev();
+    assert.equal(app.tourStep, 1);
+});
+
+test("tourPrev does not go below 0", function () {
+    var app = makeApp(5);
+    app.startTour();
+    app.tourPrev();
+    assert.equal(app.tourStep, 0);
+});
+
+test("endTour sets tourActive false", function () {
+    var app = makeApp(5);
+    app.startTour();
+    app.endTour();
+    assert.equal(app.tourActive, false);
+});
+
+test("startTour sets localStorage flag", function () {
+    localStorage.clear();
+    var app = makeApp(5);
+    app.startTour();
+    assert.equal(localStorage.getItem("clawback_toured"), "1");
+});
+
+test("startTour dismisses glow", function () {
+    var app = makeApp(5);
+    app._tourShowGlow = true;
+    app.startTour();
+    assert.equal(app._tourShowGlow, false);
+});
+
+test("_initTourGlow sets glow when no localStorage flag", function () {
+    localStorage.clear();
+    var app = makeApp(5);
+    app._initTourGlow();
+    assert.equal(app._tourShowGlow, true);
+});
+
+test("_initTourGlow does not set glow when flag exists", function () {
+    localStorage.setItem("clawback_toured", "1");
+    var app = makeApp(5);
+    app._initTourGlow();
+    assert.equal(app._tourShowGlow, false);
+});
+
+test("_dismissGlow clears glow", function () {
+    var app = makeApp(5);
+    app._tourShowGlow = true;
+    app._dismissGlow();
+    assert.equal(app._tourShowGlow, false);
+});
+
+test("getCurrentTourStep returns null when tour inactive", function () {
+    var app = makeApp(5);
+    assert.equal(app.getCurrentTourStep(), null);
+});
+
+test("getCurrentTourStep returns step when active", function () {
+    var app = makeApp(5);
+    app.startTour();
+    var step = app.getCurrentTourStep();
+    assert.equal(step.title, "Transport Controls");
+});
+
+test("tour has 5 steps", function () {
+    var app = makeApp(5);
+    assert.equal(app._tourSteps.length, 5);
+});
+
+test("Escape key closes tour", function () {
+    var app = makeApp(5);
+    app.view = "playback";
+    app.startTour();
+    assert.equal(app.tourActive, true);
+    app.handleKeydown({ code: "Escape", target: { tagName: "DIV" } });
+    assert.equal(app.tourActive, false);
+});
+
+test("startTour closes artifact panel", function () {
+    var app = makeApp(5);
+    app.artifactOpen = true;
+    app.startTour();
+    assert.equal(app.artifactOpen, false);
+});
+
+test("startTour dismisses context menu", function () {
+    var app = makeApp(5);
+    app._contextMenu = { x: 10, y: 10, items: [] };
+    app.startTour();
+    assert.equal(app._contextMenu, null);
+});
+
+test("getTourRect returns null for missing target element", function () {
+    var app = makeApp(5);
+    app.startTour();
+    // querySelector mock returns null for unknown selectors
+    var rect = app.getTourRect();
+    assert.equal(rect, null);
+});
+
+test("endTour removes resize handler", function () {
+    var app = makeApp(5);
+    app.startTour();
+    assert.notEqual(app._tourResizeHandler, null);
+    app.endTour();
+    assert.equal(app._tourResizeHandler, null);
+});
+
+test("startTour twice does not leak resize handlers", function () {
+    _windowListeners = {};
+    var app = makeApp(5);
+    app.startTour();
+    app.startTour();
+    assert.equal((_windowListeners.resize || []).length, 1, "only one resize listener should be registered");
+    app.endTour();
+    assert.equal((_windowListeners.resize || []).length, 0, "listener should be removed after endTour");
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -116,6 +116,9 @@ def test_index_has_toolbar(client):
     assert "speed-stepper" in html, "speed stepper container must be present"
     # Inner workings toggle
     assert "setInnerWorkingsMode" in html, "inner workings toggle must be present"
+    # Tour help button
+    assert "startTour()" in html, "tour help button must be present"
+    assert "toolbar__btn--help" in html, "help button class must be present"
     # Progress indicator
     assert "totalBeats" in html, "progress indicator must be present"
 


### PR DESCRIPTION
## Summary
- Adds a 5-step guided tour highlighting all major toolbar controls and the chat area
- First-time visitors see a pulsing accent-color glow on the `?` button (localStorage-based detection)
- Box-shadow cutout spotlight with smooth CSS transitions and viewport-clamped tooltip positioning
- Escape key closes tour, startTour dismisses competing overlays, window resize repositions spotlight, double-start is leak-safe

## Test plan
- [x] 20 new JS unit tests covering all tour methods, keyboard handling, overlay dismissal, resize handler lifecycle, and edge cases
- [x] Python view tests verify tour button presence in toolbar
- [x] 208 JS tests + 109 Python tests all passing

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)