### PR TITLE
feat(ui): add Up/Down arrow keyboard shortcuts for speed control

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -40,8 +40,8 @@ function clawbackApp() {
         tourActive: false,
         tourStep: 0,
         _tourSteps: [
-            { target: ".toolbar__group:first-child", title: "Transport Controls", text: "Play, pause, skip forward/back, and jump to start or end. These control the beat-by-beat playback of the session.", position: "top" },
-            { target: ".speed-stepper", title: "Speed Control", text: "Adjust playback speed from 0.5x to 4.0x. Slower speeds give you time to read dense content; faster speeds let you skim.", position: "top" },
+            { target: ".toolbar__group:first-child", title: "Transport Controls", text: "Play, pause, skip forward/back, and jump to start or end. Keyboard: Space to play/pause, Left/Right arrows to step through beats.", position: "top" },
+            { target: ".speed-stepper", title: "Speed Control", text: "Adjust playback speed from 0.5x to 4.0x. Keyboard: Up/Down arrows. Slower speeds give you time to read dense content; faster speeds let you skim.", position: "top" },
             { target: ".toolbar__label", title: "Inner Workings", text: "Toggle between Collapsed and Expanded to show or hide the AI's thinking, tool calls, and tool results. Collapsed gives a clean chat view.", position: "top" },
             { target: ".chat-area", title: "Chat Area", text: "Messages appear here as the session plays back. User messages are on the right, assistant messages on the left. Click any beat in edit mode to add annotations.", position: "bottom" },
             { target: ".toolbar__group--progress", title: "Progress Bar", text: "Shows your position in the session. The colored segments represent sections defined by the instructor. The beat counter shows your exact position.", position: "top" },
@@ -101,6 +101,14 @@ function clawbackApp() {
                 case "ArrowRight":
                     event.preventDefault();
                     this.nextBeat();
+                    break;
+                case "ArrowUp":
+                    event.preventDefault();
+                    this.increaseSpeed();
+                    break;
+                case "ArrowDown":
+                    event.preventDefault();
+                    this.decreaseSpeed();
                     break;
             }
         },

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -540,6 +540,40 @@ test("ArrowLeft goes back one beat", function () {
     assert.equal(evt.defaultPrevented, true);
 });
 
+test("ArrowUp increases speed", function () {
+    const app = makeApp(5);
+    assert.equal(app.speed, 1.0);
+    var evt = makeKeyEvent("ArrowUp");
+    app.handleKeydown(evt);
+    assert.equal(app.speed, 1.5);
+    assert.equal(evt.defaultPrevented, true);
+});
+
+test("ArrowDown decreases speed", function () {
+    const app = makeApp(5);
+    assert.equal(app.speed, 1.0);
+    var evt = makeKeyEvent("ArrowDown");
+    app.handleKeydown(evt);
+    assert.equal(app.speed, 0.5);
+    assert.equal(evt.defaultPrevented, true);
+});
+
+test("ArrowUp does not exceed max speed", function () {
+    const app = makeApp(5);
+    app.speed = 4.0;
+    var evt = makeKeyEvent("ArrowUp");
+    app.handleKeydown(evt);
+    assert.equal(app.speed, 4.0);
+});
+
+test("ArrowDown does not go below min speed", function () {
+    const app = makeApp(5);
+    app.speed = 0.5;
+    var evt = makeKeyEvent("ArrowDown");
+    app.handleKeydown(evt);
+    assert.equal(app.speed, 0.5);
+});
+
 test("keys are ignored in picker view", function () {
     const app = clawbackApp();
     app.$refs = { chatArea: { innerHTML: "", parentElement: {} } };


### PR DESCRIPTION
## Summary
- ArrowUp/ArrowDown keyboard shortcuts to increase/decrease playback speed in 0.5x steps
- Speed clamped to existing 0.5x–4.0x range, preventDefault() on both keys
- Coachmark tour text updated to document keyboard shortcuts for transport and speed controls

## Test plan
- [x] 4 new JS tests: ArrowUp/ArrowDown increase/decrease speed, bounds at max/min
- [x] 212 JS + 109 Python tests all passing

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)