### PR TITLE
feat(search): add within-session beat search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test-js:
 	node tests/unit/js/test_renderer.js
 	node tests/unit/js/test_scroller.js
 	node tests/unit/js/test_annotations.js
+	node tests/unit/js/test_search.js
 	node tests/unit/js/test_app.js
 
 test-integration:

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1796,3 +1796,154 @@ body {
     background-color: var(--color-accent-hover);
     color: #fff;
 }
+
+/* ===================================================================
+   Search sidebar
+   =================================================================== */
+
+.search-sidebar {
+    width: var(--sidebar-width);
+    flex-shrink: 0;
+    background-color: var(--color-surface);
+    border-right: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    padding-bottom: var(--toolbar-height);
+}
+
+.search-sidebar__header {
+    padding: 16px;
+    border-bottom: 1px solid var(--color-border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.search-sidebar__title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.search-sidebar__close {
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    font-size: 1.2rem;
+    cursor: pointer;
+    padding: 0 4px;
+}
+
+.search-sidebar__close:hover {
+    color: var(--color-text);
+}
+
+.search-sidebar__input-wrap {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.search-sidebar__input {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font-size: 0.875rem;
+    font-family: inherit;
+    outline: none;
+    box-sizing: border-box;
+    transition: border-color 0.2s;
+}
+
+.search-sidebar__input:focus {
+    border-color: var(--color-accent);
+}
+
+.search-sidebar__count {
+    padding: 8px 16px;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.search-sidebar__results {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.search-sidebar__result {
+    padding: 10px 16px;
+    cursor: pointer;
+    border-bottom: 1px solid rgba(42, 42, 74, 0.5);
+    transition: background-color 0.15s;
+}
+
+.search-sidebar__result:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.search-sidebar__result--active {
+    background-color: rgba(233, 69, 96, 0.1);
+    border-left: 3px solid var(--color-accent);
+    padding-left: 13px;
+}
+
+.search-sidebar__result-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+}
+
+.search-sidebar__result-icon {
+    font-size: 0.85rem;
+}
+
+.search-sidebar__result-type {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    text-transform: capitalize;
+}
+
+.search-sidebar__result-beat {
+    font-size: 0.7rem;
+    color: var(--color-text-muted);
+    margin-left: auto;
+    font-family: var(--font-mono);
+}
+
+.search-sidebar__result-snippet {
+    font-size: 0.8rem;
+    color: var(--color-text);
+    line-height: 1.4;
+    word-break: break-word;
+}
+
+.search-sidebar__result-snippet mark {
+    background-color: rgba(233, 69, 96, 0.3);
+    color: var(--color-text);
+    padding: 0 2px;
+    border-radius: 2px;
+}
+
+.search-sidebar__empty {
+    padding: 24px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+}
+
+/* Search highlight on target beat */
+.search-highlight {
+    outline: 2px solid var(--color-accent) !important;
+    outline-offset: 2px;
+    animation: search-pulse 1.5s ease-out forwards;
+}
+
+@keyframes search-pulse {
+    0% { outline-color: var(--color-accent); }
+    100% { outline-color: transparent; }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -16,6 +16,7 @@
     <script defer src="/static/js/renderer.js"></script>
     <script defer src="/static/js/scroller.js"></script>
     <script defer src="/static/js/annotations.js"></script>
+    <script defer src="/static/js/search.js"></script>
     <script defer src="/static/js/app.js"></script>
     <!-- Alpine.js MUST be last — defer scripts execute in order, and Alpine
          needs clawbackApp() to be defined before it initializes -->
@@ -55,6 +56,47 @@
                                 title="Delete section">&times;</button>
                     </div>
                 </template>
+            </div>
+        </aside>
+
+        <!-- Search sidebar -->
+        <aside class="search-sidebar"
+               x-show="view === 'playback' && searchOpen"
+               x-transition.opacity.duration.200ms
+               x-cloak>
+            <div class="search-sidebar__header">
+                <span class="search-sidebar__title">Search</span>
+                <button class="search-sidebar__close" @click="closeSearch()" title="Close search">&times;</button>
+            </div>
+            <div class="search-sidebar__input-wrap">
+                <input class="search-sidebar__input"
+                       type="text"
+                       x-model="searchQuery"
+                       @input="performSearch()"
+                       placeholder="Search beats..."
+                       x-ref="searchInput">
+            </div>
+            <div class="search-sidebar__count"
+                 x-show="searchQuery.length > 0"
+                 x-text="searchResults.length + ' result' + (searchResults.length !== 1 ? 's' : '')"></div>
+            <div class="search-sidebar__results">
+                <template x-for="(result, idx) in searchResults" :key="result.beatIndex">
+                    <div class="search-sidebar__result"
+                         :class="{ 'search-sidebar__result--active': searchSelectedIndex === idx }"
+                         @click="searchSelectedIndex = idx; jumpToSearchResult(result)">
+                        <div class="search-sidebar__result-header">
+                            <span class="search-sidebar__result-icon" x-text="getBeatTypeIcon(result.type)"></span>
+                            <span class="search-sidebar__result-type" x-text="result.type.replace(/_/g, ' ')"></span>
+                            <span class="search-sidebar__result-beat"
+                                  x-text="'#' + (typeof result.beatId === 'number' ? result.beatId + 1 : result.beatId)"></span>
+                        </div>
+                        <div class="search-sidebar__result-snippet" x-html="getSearchSnippet(result)"></div>
+                    </div>
+                </template>
+                <div class="search-sidebar__empty"
+                     x-show="searchQuery.length > 0 && searchResults.length === 0">
+                    No matches found.
+                </div>
             </div>
         </aside>
 
@@ -236,6 +278,16 @@
                     :class="{ 'toolbar__btn--glow': _tourShowGlow }"
                     @click="startTour()"
                     title="Take a tour">?</button>
+        </div>
+
+        <div class="toolbar__separator"></div>
+
+        <!-- Search toggle -->
+        <div class="toolbar__group">
+            <button class="toolbar__btn toolbar__btn--iw"
+                    :class="{ 'toolbar__btn--active': searchOpen }"
+                    @click="searchOpen ? closeSearch() : openSearch()"
+                    title="Search (/)">&#128269; Search</button>
         </div>
 
         <div class="toolbar__separator"></div>

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -34,6 +34,11 @@ function clawbackApp() {
         _inlineEditor: null,
         _activeEditForm: null,
         _uploadForm: null,
+        searchOpen: false,
+        searchQuery: "",
+        searchResults: [],
+        searchSelectedIndex: -1,
+        _searchHighlightTimer: null,
         _engine: null,
         _scroller: null,
         _conversationBeatsRendered: 0,
@@ -79,6 +84,8 @@ function clawbackApp() {
             if (event.code === "Escape") {
                 if (this.tourActive) {
                     this.endTour();
+                } else if (this.searchOpen) {
+                    this.closeSearch();
                 } else if (this._activeEditForm) {
                     this._dismissEditForm();
                 } else if (this._sectionForm) {
@@ -93,6 +100,28 @@ function clawbackApp() {
                     this.closeArtifact();
                 }
                 return;
+            }
+
+            // Search input: arrow keys navigate results, Enter jumps
+            if (this.searchOpen && event.target === this.$refs.searchInput) {
+                if (event.code === "ArrowDown") {
+                    event.preventDefault();
+                    this.searchNext();
+                    return;
+                }
+                if (event.code === "ArrowUp") {
+                    event.preventDefault();
+                    this.searchPrev();
+                    return;
+                }
+                if (event.code === "Enter") {
+                    event.preventDefault();
+                    if (this.searchResults.length > 0 && this.searchSelectedIndex >= 0) {
+                        this.jumpToSearchResult(this.searchResults[this.searchSelectedIndex]);
+                    }
+                    return;
+                }
+                return; // Let other keys type into the search input
             }
 
             var tag = event.target.tagName;
@@ -119,6 +148,10 @@ function clawbackApp() {
                 case "ArrowDown":
                     event.preventDefault();
                     this.decreaseSpeed();
+                    break;
+                case "Slash":
+                    event.preventDefault();
+                    this.openSearch();
                     break;
             }
         },
@@ -298,6 +331,11 @@ function clawbackApp() {
             this._beatIdToMergedIndex = null;
             this.artifactOpen = false;
             this._currentArtifact = null;
+            this.searchOpen = false;
+            this.searchQuery = "";
+            this.searchResults = [];
+            this.searchSelectedIndex = -1;
+            this._clearSearchHighlight();
             this.editMode = false;
             this._contextMenu = null;
             this.editToast = "";
@@ -593,6 +631,136 @@ function clawbackApp() {
             if (panelContent) {
                 panelContent.innerHTML = "";
             }
+        },
+
+        // -------------------------------------------------------------------
+        // Search
+        // -------------------------------------------------------------------
+
+        /** Open the search sidebar and pause playback. */
+        openSearch() {
+            if (this.searchOpen) return;
+            if (this._engine && this.playbackState === "PLAYING") {
+                this._engine.pause();
+            }
+            this.searchOpen = true;
+            this.$nextTick(function () {
+                if (this.$refs.searchInput) this.$refs.searchInput.focus();
+            }.bind(this));
+        },
+
+        /** Close the search sidebar and clear state. */
+        closeSearch() {
+            this.searchOpen = false;
+            this.searchQuery = "";
+            this.searchResults = [];
+            this.searchSelectedIndex = -1;
+            this._clearSearchHighlight();
+        },
+
+        /** Run a search against the loaded beats. */
+        performSearch() {
+            if (!this.searchQuery.trim() || !this._engine) {
+                this.searchResults = [];
+                this.searchSelectedIndex = -1;
+                return;
+            }
+            if (typeof ClawbackSearch !== "undefined") {
+                this.searchResults = ClawbackSearch.search(
+                    this._engine.beats, this.searchQuery
+                );
+            }
+            this.searchSelectedIndex = this.searchResults.length > 0 ? 0 : -1;
+        },
+
+        /** Jump to a search result beat. */
+        jumpToSearchResult(result) {
+            if (!this._engine || !result) return;
+
+            // Resolve merged index — same pattern as jumpToSection.
+            // result.beatIndex is an index into _engine.beats (the merged array).
+            // When _beatIdToMergedIndex is null (no annotations), merged === original.
+            var mergedIndex = this._beatIdToMergedIndex
+                ? this._beatIdToMergedIndex[result.beatId]
+                : result.beatIndex;
+            if (mergedIndex === undefined) mergedIndex = result.beatIndex;
+
+            this._engine.jumpToBeat(mergedIndex + 1);
+            this.currentBeat = this._conversationBeatsRendered;
+            this._updateActiveSection();
+
+            // Auto-expand collapsed inner workings group if needed
+            this.$nextTick(function () {
+                var el = document.querySelector('[data-beat-id="' + result.beatId + '"]');
+                if (!el && result.groupId != null) {
+                    // Beat is inside a collapsed IW group — expand it
+                    var card = document.querySelector('[data-group-id="' + result.groupId + '"]');
+                    if (card && card.classList.contains("iw-card--collapsed")) {
+                        var toggle = card.querySelector(".iw-card__toggle");
+                        if (toggle) toggle.click();
+                    }
+                    el = document.querySelector('[data-beat-id="' + result.beatId + '"]');
+                }
+                if (el) {
+                    el.scrollIntoView({ behavior: "smooth", block: "center" });
+                    this._applySearchHighlight(el);
+                } else if (this._scroller) {
+                    this._scroller.scrollToBottom();
+                }
+            }.bind(this));
+        },
+
+        /** Navigate to the next search result and jump to it. */
+        searchNext() {
+            if (this.searchResults.length === 0) return;
+            this.searchSelectedIndex = (this.searchSelectedIndex + 1) % this.searchResults.length;
+            this.jumpToSearchResult(this.searchResults[this.searchSelectedIndex]);
+        },
+
+        /** Navigate to the previous search result and jump to it. */
+        searchPrev() {
+            if (this.searchResults.length === 0) return;
+            this.searchSelectedIndex = (this.searchSelectedIndex - 1 + this.searchResults.length) % this.searchResults.length;
+            this.jumpToSearchResult(this.searchResults[this.searchSelectedIndex]);
+        },
+
+        /** Get an HTML snippet with match highlighted for a search result. */
+        getSearchSnippet(result) {
+            if (typeof ClawbackSearch === "undefined") return "";
+            var s = ClawbackSearch.snippet(result.content, this.searchQuery);
+            if (!s) return "";
+            var esc = function (t) {
+                return t.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+            };
+            return esc(s.before) + "<mark>" + esc(s.match) + "</mark>" + esc(s.after);
+        },
+
+        /** Get the icon for a beat type. */
+        getBeatTypeIcon(type) {
+            if (typeof ClawbackSearch !== "undefined") {
+                return ClawbackSearch.beatTypeIcon(type);
+            }
+            return "\u2022";
+        },
+
+        /** Apply a temporary highlight to a DOM element. */
+        _applySearchHighlight(el) {
+            this._clearSearchHighlight();
+            el.classList.add("search-highlight");
+            this._searchHighlightTimer = setTimeout(function () {
+                el.classList.remove("search-highlight");
+                this._searchHighlightTimer = null;
+            }.bind(this), 1500);
+        },
+
+        /** Clear any active search highlight. */
+        _clearSearchHighlight() {
+            if (this._searchHighlightTimer) {
+                clearTimeout(this._searchHighlightTimer);
+                this._searchHighlightTimer = null;
+            }
+            var highlighted = document.querySelector(".search-highlight");
+            if (highlighted) highlighted.classList.remove("search-highlight");
         },
 
         /** Toggle annotation editing mode. */
@@ -1606,6 +1774,7 @@ function clawbackApp() {
                 for (var j = 0; j < annotations.length; j++) {
                     if (annotations[j].type === "callout") {
                         var callout = annotations[j].data;
+                        var calloutBeatId = "callout-" + callout.id;
                         merged.push({
                             type: "callout",
                             category: "callout",
@@ -1613,12 +1782,14 @@ function clawbackApp() {
                             calloutStyle: callout.style || "note",
                             content: callout.content || "",
                             calloutId: callout.id,
-                            id: "callout-" + callout.id,
+                            id: calloutBeatId,
                             duration: this._calculateCalloutDuration(callout.content),
                             group_id: null,
                         });
+                        indexMap[calloutBeatId] = merged.length - 1;
                     } else if (annotations[j].type === "artifact") {
                         var artifact = annotations[j].data;
+                        var artifactBeatId = "artifact-" + artifact.id;
                         merged.push({
                             type: "artifact",
                             category: "artifact",
@@ -1629,12 +1800,13 @@ function clawbackApp() {
                             contentType: artifact.content_type || "markdown",
                             content: (artifact.title || "") + " " + (artifact.description || ""),
                             artifactId: artifact.id,
-                            id: "artifact-" + artifact.id,
+                            id: artifactBeatId,
                             duration: this._calculateCalloutDuration(
                                 (artifact.title || "") + " " + (artifact.description || "")
                             ),
                             group_id: null,
                         });
+                        indexMap[artifactBeatId] = merged.length - 1;
                     }
                 }
             }

--- a/app/static/js/search.js
+++ b/app/static/js/search.js
@@ -1,0 +1,102 @@
+/**
+ * Clawback — Within-session search engine.
+ *
+ * Pure-logic module: takes beats and a query, returns results.
+ * No DOM manipulation — keeps it testable via Node.js.
+ */
+
+var ClawbackSearch = {
+    /**
+     * Search a beat array for case-insensitive substring matches.
+     *
+     * @param {Array<Object>} beats - The merged beat array
+     * @param {string} query - Search query
+     * @returns {Array<Object>} Array of result objects in beat order
+     */
+    search: function (beats, query) {
+        if (!beats || !query || !query.trim()) return [];
+        var q = query.trim().toLowerCase();
+        var results = [];
+
+        for (var i = 0; i < beats.length; i++) {
+            var beat = beats[i];
+            var searchable = beat.content || "";
+
+            // For artifacts, also search title, description, and full content
+            if (beat.isArtifact) {
+                searchable = [
+                    beat.artifactTitle || "",
+                    beat.artifactDescription || "",
+                    beat.artifactContent || "",
+                    searchable,
+                ].join(" ");
+            }
+
+            if (!searchable || searchable.toLowerCase().indexOf(q) === -1) continue;
+
+            results.push({
+                beatIndex: i,
+                beatId: beat.id,
+                type: beat.type || (beat.isCallout ? "callout" : beat.isArtifact ? "artifact" : "unknown"),
+                category: beat.category || "",
+                content: searchable,
+                groupId: beat.group_id != null ? beat.group_id : null,
+            });
+        }
+
+        return results;
+    },
+
+    /**
+     * Extract a snippet from content centered on the first match.
+     * Returns { before, match, after } for rendering with <mark> tags.
+     *
+     * @param {string} content - Full text content
+     * @param {string} query - The search query
+     * @returns {{ before: string, match: string, after: string }|null}
+     */
+    snippet: function (content, query) {
+        if (!content || !query) return null;
+        var lower = content.toLowerCase();
+        var q = query.trim().toLowerCase();
+        var idx = lower.indexOf(q);
+        if (idx === -1) return null;
+
+        var windowSize = 30; // chars on each side of match
+        var start = Math.max(0, idx - windowSize);
+        var end = Math.min(content.length, idx + q.length + windowSize);
+
+        var before = content.slice(start, idx);
+        var match = content.slice(idx, idx + q.length);
+        var after = content.slice(idx + q.length, end);
+
+        if (start > 0) before = "\u2026" + before;
+        if (end < content.length) after = after + "\u2026";
+
+        return { before: before, match: match, after: after };
+    },
+
+    /**
+     * Get a display icon for a beat type.
+     *
+     * @param {string} type - Beat type
+     * @returns {string} Unicode icon
+     */
+    beatTypeIcon: function (type) {
+        switch (type) {
+            case "user_message": return "\uD83D\uDCAC";
+            case "assistant_message": return "\uD83E\uDD16";
+            case "thinking": return "\uD83D\uDCAD";
+            case "tool_call": return "\uD83D\uDD27";
+            case "tool_result": return "\uD83D\uDCCB";
+            case "callout": return "\uD83D\uDCDD";
+            case "artifact": return "\uD83D\uDCC4";
+            default: return "\u2022";
+        }
+    },
+};
+
+// CommonJS export for Node.js testing
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { ClawbackSearch: ClawbackSearch };
+}

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -50,6 +50,9 @@ const { ClawbackAnnotations, ANNOTATION_COLORS } = require("../../../app/static/
 global.ClawbackAnnotations = ClawbackAnnotations;
 global.ANNOTATION_COLORS = ANNOTATION_COLORS;
 
+const { ClawbackSearch } = require("../../../app/static/js/search.js");
+global.ClawbackSearch = ClawbackSearch;
+
 // Mock save to prevent actual HTTP calls
 var saveCalls = 0;
 ClawbackAnnotations.save = function () { saveCalls++; return Promise.resolve(); };
@@ -2692,6 +2695,134 @@ test("startTour twice does not leak resize handlers", function () {
     assert.equal((_windowListeners.resize || []).length, 1, "only one resize listener should be registered");
     app.endTour();
     assert.equal((_windowListeners.resize || []).length, 0, "listener should be removed after endTour");
+});
+
+// ---------------------------------------------------------------------------
+// Search tests
+// ---------------------------------------------------------------------------
+
+test("searchOpen defaults to false", function () {
+    const app = makeApp(5);
+    assert.equal(app.searchOpen, false);
+});
+
+test("openSearch sets searchOpen and pauses playback", function () {
+    const app = makeApp(5);
+    app.$nextTick = function (fn) { fn.call(app); };
+    app.$refs = { searchInput: { focus: function () {} } };
+    app.playbackState = "PLAYING";
+    app.openSearch();
+    assert.equal(app.searchOpen, true);
+});
+
+test("closeSearch clears all search state", function () {
+    const app = makeApp(5);
+    app.searchOpen = true;
+    app.searchQuery = "test";
+    app.searchResults = [{ beatIndex: 0 }];
+    app.searchSelectedIndex = 0;
+    app.closeSearch();
+    assert.equal(app.searchOpen, false);
+    assert.equal(app.searchQuery, "");
+    assert.equal(app.searchResults.length, 0);
+    assert.equal(app.searchSelectedIndex, -1);
+});
+
+test("performSearch populates results from engine beats", function () {
+    const app = makeApp(5);
+    // Simulate engine with beats
+    app._engine = {
+        beats: [
+            { id: 0, type: "user_message", content: "hello world", category: "direct", group_id: null },
+            { id: 1, type: "assistant_message", content: "goodbye world", category: "direct", group_id: null },
+        ],
+        pause: function () {},
+        jumpToBeat: function () {},
+    };
+    app.searchQuery = "hello";
+    app.performSearch();
+    assert.equal(app.searchResults.length, 1);
+    assert.equal(app.searchResults[0].beatId, 0);
+    assert.equal(app.searchSelectedIndex, 0);
+});
+
+test("performSearch clears results for empty query", function () {
+    const app = makeApp(5);
+    app._engine = { beats: [{ id: 0, type: "user_message", content: "hello", category: "direct", group_id: null }] };
+    app.searchQuery = "";
+    app.performSearch();
+    assert.equal(app.searchResults.length, 0);
+    assert.equal(app.searchSelectedIndex, -1);
+});
+
+test("/ key opens search in playback view", function () {
+    const app = makeApp(5);
+    app.$nextTick = function (fn) { fn.call(app); };
+    app.$refs = { searchInput: { focus: function () {} } };
+    app.view = "playback";
+    var evt = makeKeyEvent("Slash");
+    app.handleKeydown(evt);
+    assert.equal(app.searchOpen, true);
+    assert.equal(evt.defaultPrevented, true);
+});
+
+test("Escape closes search when open", function () {
+    const app = makeApp(5);
+    app.view = "playback";
+    app.searchOpen = true;
+    app.handleKeydown(makeKeyEvent("Escape"));
+    assert.equal(app.searchOpen, false);
+});
+
+test("backToSessions clears search state", function () {
+    const app = makeApp(5);
+    app.searchOpen = true;
+    app.searchQuery = "test";
+    app.searchResults = [{ beatIndex: 0 }];
+    app.searchSelectedIndex = 0;
+    app.backToSessions();
+    assert.equal(app.searchOpen, false);
+    assert.equal(app.searchQuery, "");
+    assert.equal(app.searchResults.length, 0);
+    assert.equal(app.searchSelectedIndex, -1);
+});
+
+test("searchNext wraps around and jumps", function () {
+    const app = makeApp(5);
+    app.$nextTick = function (fn) { fn.call(app); };
+    app._engine = { beats: [], jumpToBeat: function () {}, pause: function () {} };
+    app.searchResults = [{ beatIndex: 0, beatId: 0 }, { beatIndex: 1, beatId: 1 }, { beatIndex: 2, beatId: 2 }];
+    app.searchSelectedIndex = 2;
+    app.searchNext();
+    assert.equal(app.searchSelectedIndex, 0);
+});
+
+test("searchPrev wraps around and jumps", function () {
+    const app = makeApp(5);
+    app.$nextTick = function (fn) { fn.call(app); };
+    app._engine = { beats: [], jumpToBeat: function () {}, pause: function () {} };
+    app.searchResults = [{ beatIndex: 0, beatId: 0 }, { beatIndex: 1, beatId: 1 }, { beatIndex: 2, beatId: 2 }];
+    app.searchSelectedIndex = 0;
+    app.searchPrev();
+    assert.equal(app.searchSelectedIndex, 2);
+});
+
+test("getSearchSnippet returns HTML with mark tag", function () {
+    const app = makeApp(5);
+    app.searchQuery = "hello";
+    var result = { content: "say hello world", beatIndex: 0 };
+    var html = app.getSearchSnippet(result);
+    assert.ok(html.indexOf("<mark>") !== -1, "should contain <mark> tag");
+    assert.ok(html.indexOf("hello") !== -1, "should contain match text");
+});
+
+test("getSearchSnippet escapes HTML in content", function () {
+    const app = makeApp(5);
+    app.searchQuery = "script";
+    var result = { content: "<script>alert('xss')</script>", beatIndex: 0 };
+    var html = app.getSearchSnippet(result);
+    assert.ok(html.indexOf("<script>") === -1, "should not contain raw <script> tag");
+    assert.ok(html.indexOf("&lt;") !== -1, "should escape angle brackets");
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/js/test_search.js
+++ b/tests/unit/js/test_search.js
@@ -1,0 +1,263 @@
+/**
+ * Clawback — Unit tests for the search engine module.
+ *
+ * Run with: node tests/unit/js/test_search.js
+ * Or via:   make test-js
+ */
+
+const assert = require("node:assert/strict");
+const { ClawbackSearch } = require("../../../app/static/js/search.js");
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        passed++;
+        console.log(`  \u2713 ${name}`);
+    } catch (err) {
+        failed++;
+        console.log(`  \u2717 ${name}`);
+        console.log(`    ${err.message}`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBeat(id, type, content, opts) {
+    return Object.assign({
+        id: id,
+        type: type,
+        content: content,
+        category: type === "user_message" || type === "assistant_message" ? "direct" : "inner_working",
+        group_id: null,
+    }, opts || {});
+}
+
+function makeBeats() {
+    return [
+        makeBeat(0, "user_message", "How do I configure Docker networking?"),
+        makeBeat(1, "assistant_message", "Docker networking uses bridge networks by default."),
+        makeBeat(2, "thinking", "The user wants to know about Docker network configuration."),
+        makeBeat(3, "tool_call", "docker network ls\n--format json"),
+        makeBeat(4, "tool_result", "bridge   host   none"),
+        makeBeat(5, "user_message", "What about custom bridge networks?"),
+        makeBeat(6, "assistant_message", "You can create custom networks with docker network create."),
+    ];
+}
+
+// ---------------------------------------------------------------------------
+// search() tests
+// ---------------------------------------------------------------------------
+
+console.log("\nsearch()");
+
+test("returns matching beats for a query", function () {
+    var beats = makeBeats();
+    var results = ClawbackSearch.search(beats, "Docker");
+    assert.ok(results.length >= 2, "should match multiple beats mentioning Docker");
+});
+
+test("is case-insensitive", function () {
+    var beats = makeBeats();
+    var lower = ClawbackSearch.search(beats, "docker");
+    var upper = ClawbackSearch.search(beats, "DOCKER");
+    assert.equal(lower.length, upper.length, "case should not matter");
+    assert.ok(lower.length > 0);
+});
+
+test("returns empty array when no matches", function () {
+    var beats = makeBeats();
+    var results = ClawbackSearch.search(beats, "kubernetes");
+    assert.equal(results.length, 0);
+});
+
+test("returns empty array for empty query", function () {
+    var beats = makeBeats();
+    assert.equal(ClawbackSearch.search(beats, "").length, 0);
+    assert.equal(ClawbackSearch.search(beats, "   ").length, 0);
+});
+
+test("returns empty array for null/undefined inputs", function () {
+    assert.equal(ClawbackSearch.search(null, "test").length, 0);
+    assert.equal(ClawbackSearch.search([], null).length, 0);
+    assert.equal(ClawbackSearch.search(undefined, "test").length, 0);
+});
+
+test("searches all beat types", function () {
+    var beats = makeBeats();
+    // "bridge" appears in assistant (beat 1), tool_result (beat 4), assistant (beat 5 mentions "custom bridge")
+    var results = ClawbackSearch.search(beats, "bridge");
+    var types = results.map(function (r) { return r.type; });
+    assert.ok(types.indexOf("assistant_message") !== -1, "should find in assistant_message");
+    assert.ok(types.indexOf("tool_result") !== -1, "should find in tool_result");
+});
+
+test("searches thinking beats", function () {
+    var beats = makeBeats();
+    var results = ClawbackSearch.search(beats, "wants to know");
+    assert.equal(results.length, 1);
+    assert.equal(results[0].type, "thinking");
+});
+
+test("searches tool_call beats", function () {
+    var beats = makeBeats();
+    var results = ClawbackSearch.search(beats, "network ls");
+    assert.equal(results.length, 1);
+    assert.equal(results[0].type, "tool_call");
+});
+
+test("results are in beat order", function () {
+    var beats = makeBeats();
+    var results = ClawbackSearch.search(beats, "network");
+    for (var i = 1; i < results.length; i++) {
+        assert.ok(results[i].beatIndex > results[i - 1].beatIndex,
+            "results must be in ascending beat order");
+    }
+});
+
+test("result objects have correct shape", function () {
+    var beats = makeBeats();
+    var results = ClawbackSearch.search(beats, "Docker");
+    var r = results[0];
+    assert.equal(typeof r.beatIndex, "number");
+    assert.ok(r.beatId !== undefined);
+    assert.equal(typeof r.type, "string");
+    assert.equal(typeof r.category, "string");
+    assert.equal(typeof r.content, "string");
+});
+
+test("includes callout pseudo-beats", function () {
+    var beats = [
+        makeBeat(0, "user_message", "hello"),
+        { id: "callout-1", isCallout: true, content: "Important note about testing", category: "callout", group_id: null },
+    ];
+    var results = ClawbackSearch.search(beats, "testing");
+    assert.equal(results.length, 1);
+    assert.equal(results[0].type, "callout");
+    assert.equal(results[0].beatId, "callout-1");
+});
+
+test("includes artifact pseudo-beats and searches title/description/content", function () {
+    var beats = [
+        makeBeat(0, "user_message", "show me code"),
+        {
+            id: "artifact-1", isArtifact: true, content: "",
+            artifactTitle: "Dockerfile Example",
+            artifactDescription: "A multi-stage build",
+            artifactContent: "FROM node:18\nRUN npm install",
+            category: "artifact", group_id: null,
+        },
+    ];
+    // Search by title
+    var r1 = ClawbackSearch.search(beats, "Dockerfile");
+    assert.equal(r1.length, 1);
+    assert.equal(r1[0].type, "artifact");
+
+    // Search by description
+    var r2 = ClawbackSearch.search(beats, "multi-stage");
+    assert.equal(r2.length, 1);
+
+    // Search by content
+    var r3 = ClawbackSearch.search(beats, "npm install");
+    assert.equal(r3.length, 1);
+});
+
+test("preserves groupId for inner working beats", function () {
+    var beats = [
+        makeBeat(0, "thinking", "analyzing the problem", { group_id: 3 }),
+    ];
+    var results = ClawbackSearch.search(beats, "analyzing");
+    assert.equal(results[0].groupId, 3);
+});
+
+test("groupId is null for direct beats", function () {
+    var beats = [makeBeat(0, "user_message", "hello world")];
+    var results = ClawbackSearch.search(beats, "hello");
+    assert.equal(results[0].groupId, null);
+});
+
+// ---------------------------------------------------------------------------
+// snippet() tests
+// ---------------------------------------------------------------------------
+
+console.log("\nsnippet()");
+
+test("extracts snippet centered on match", function () {
+    var content = "The quick brown fox jumps over the lazy dog and runs away fast";
+    var s = ClawbackSearch.snippet(content, "jumps");
+    assert.ok(s !== null);
+    assert.equal(s.match, "jumps");
+    assert.ok(s.before.length > 0);
+    assert.ok(s.after.length > 0);
+});
+
+test("handles match at start of content", function () {
+    var s = ClawbackSearch.snippet("Docker is great for containers", "Docker");
+    assert.equal(s.match, "Docker");
+    assert.equal(s.before, "");
+    assert.ok(s.after.length > 0);
+});
+
+test("handles match at end of content", function () {
+    var s = ClawbackSearch.snippet("I love using Docker", "Docker");
+    assert.equal(s.match, "Docker");
+    assert.ok(s.before.length > 0);
+    assert.equal(s.after, "");
+});
+
+test("handles short content (no truncation needed)", function () {
+    var s = ClawbackSearch.snippet("hello world", "hello");
+    assert.equal(s.before, "");
+    assert.equal(s.match, "hello");
+    assert.equal(s.after, " world");
+});
+
+test("adds ellipsis when truncated", function () {
+    var content = "A".repeat(50) + "MATCH" + "B".repeat(50);
+    var s = ClawbackSearch.snippet(content, "MATCH");
+    assert.ok(s.before.startsWith("\u2026"), "should start with ellipsis when truncated");
+    assert.ok(s.after.endsWith("\u2026"), "should end with ellipsis when truncated");
+});
+
+test("returns null for no match", function () {
+    assert.equal(ClawbackSearch.snippet("hello", "xyz"), null);
+});
+
+test("returns null for null inputs", function () {
+    assert.equal(ClawbackSearch.snippet(null, "test"), null);
+    assert.equal(ClawbackSearch.snippet("test", null), null);
+});
+
+test("is case-insensitive but preserves original case in match", function () {
+    var s = ClawbackSearch.snippet("Hello World", "hello");
+    assert.equal(s.match, "Hello");
+});
+
+// ---------------------------------------------------------------------------
+// beatTypeIcon() tests
+// ---------------------------------------------------------------------------
+
+console.log("\nbeatTypeIcon()");
+
+test("returns icon for each beat type", function () {
+    var types = ["user_message", "assistant_message", "thinking", "tool_call", "tool_result", "callout", "artifact"];
+    types.forEach(function (t) {
+        var icon = ClawbackSearch.beatTypeIcon(t);
+        assert.ok(icon.length > 0, t + " should have an icon");
+        assert.notEqual(icon, "\u2022", t + " should not use default bullet");
+    });
+});
+
+test("returns bullet for unknown type", function () {
+    assert.equal(ClawbackSearch.beatTypeIcon("unknown"), "\u2022");
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -15,6 +15,7 @@ def test_index_loads_all_required_scripts(client):
     assert "playback.js" in html, "playback.js must be loaded"
     assert "renderer.js" in html, "renderer.js must be loaded"
     assert "scroller.js" in html, "scroller.js must be loaded"
+    assert "search.js" in html, "search.js must be loaded"
     assert "app.js" in html, "app.js must be loaded"
     assert "alpinejs" in html, "Alpine.js must be loaded"
     assert "marked" in html, "marked.js must be loaded"
@@ -39,6 +40,8 @@ def test_index_script_load_order(client):
             return "renderer"
         if "scroller.js" in src:
             return "scroller"
+        if "search.js" in src:
+            return "search"
         if "app.js" in src:
             return "app"
         if "alpinejs" in src:
@@ -72,6 +75,9 @@ def test_index_script_load_order(client):
     )
     assert order.index("scroller") < order.index("app"), (
         "scroller.js must load before app.js"
+    )
+    assert order.index("search") < order.index("app"), (
+        "search.js must load before app.js"
     )
     assert order.index("app") < order.index("alpine"), (
         "app.js must load before Alpine.js"
@@ -119,6 +125,9 @@ def test_index_has_toolbar(client):
     # Tour help button
     assert "startTour()" in html, "tour help button must be present"
     assert "toolbar__btn--help" in html, "help button class must be present"
+    # Search button
+    assert "openSearch" in html, "search button must be present"
+    assert "closeSearch" in html, "search close must be present"
     # Progress indicator
     assert "totalBeats" in html, "progress indicator must be present"
 


### PR DESCRIPTION
## Summary

- Add search sidebar for finding content within a loaded session — press `/` to open
- Pure client-side: case-insensitive substring match across all beat types (messages, thinking, tool calls, annotations)
- Click results to jump directly to matching beats with highlight animation
- Arrow keys auto-navigate through results, Escape closes

## Changes

**New files:**
- `app/static/js/search.js` — Search engine module (`search()`, `snippet()`, `beatTypeIcon()`)
- `tests/unit/js/test_search.js` — 24 unit tests for search module

**Modified:**
- `app/static/js/app.js` — Search state, 10 methods, keyboard shortcuts, pseudo-beat IDs in `_buildMergedBeats`
- `app/static/index.html` — Search sidebar, toolbar button, `<script>` tag
- `app/static/css/style.css` — Search sidebar styles + highlight animation
- `tests/unit/js/test_app.js` — 12 search integration tests
- `tests/unit/test_views.py` — Search button + script order assertions
- `Makefile` — Added `test_search.js` to `test-js` target

## Test plan
- [ ] 24 search module tests pass
- [ ] 228 app JS tests pass (including 12 new search tests)
- [ ] 118 Python unit tests pass
- [ ] Press `/` in playback view — search sidebar opens
- [ ] Type query — results appear in real-time with highlighted snippets
- [ ] Click result — jumps to beat with accent-color outline animation
- [ ] Arrow keys navigate results and auto-jump
- [ ] Escape closes search
- [ ] Match in collapsed IW group — auto-expands on jump

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)