### PR TITLE
feat(api): ephemeral session upload and deep-link autoplay (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ All configuration is via environment variables:
 |----------|---------|-------------|
 | `PORT` | `8080` | Port the server listens on |
 | `CLAWBACK_SECRET` | *(unset)* | When set, all routes except `/health` require this secret |
+| `CLAWBACK_READ_ONLY` | *(unset)* | When set to `true`, disables editing and curated uploads |
+| `CLAWBACK_EPHEMERAL_TTL` | `14400` | Time-to-live for ephemeral sessions in seconds (default 4 hours) |
 
 ### Access gating
 

--- a/app/config.py
+++ b/app/config.py
@@ -10,5 +10,6 @@ class Config:
         "true",
         "yes",
     )
+    CLAWBACK_EPHEMERAL_TTL = int(os.environ.get("CLAWBACK_EPHEMERAL_TTL", 14400))
     PORT = int(os.environ.get("PORT", 8080))
     DEBUG = os.environ.get("FLASK_DEBUG", "false").lower() == "true"

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -29,7 +29,8 @@ def list_sessions():
 @api_bp.route("/sessions/upload", methods=["POST"])
 def upload_session():
     """Upload a new session JSONL with metadata."""
-    if current_app.config["CLAWBACK_READ_ONLY"]:
+    ephemeral = request.form.get("ephemeral", "").lower() in ("1", "true", "yes")
+    if current_app.config["CLAWBACK_READ_ONLY"] and not ephemeral:
         return jsonify({"status": "error", "message": "Read-only mode"}), 403
     file = request.files.get("file")
     title = request.form.get("title", "").strip()
@@ -72,6 +73,26 @@ def upload_session():
             400,
         )
 
+    # Build manifest entry
+    tags = [t.strip() for t in tags_raw.split(",") if t.strip()] if tags_raw else []
+    entry = {
+        "id": session_id,
+        "title": title,
+        "description": description,
+        "file": filename,
+        "beat_count": len(result["beats"]),
+        "tags": tags,
+    }
+
+    if ephemeral:
+        # Memory-only: no disk write, no manifest update
+        cache = current_app.session_cache
+        cache.sweep_ephemeral(current_app.config["CLAWBACK_EPHEMERAL_TTL"])
+        cache.add_ephemeral(session_id, entry, result["beats"])
+        return jsonify({"status": "ok", "session": entry}), 201
+
+    # --- Curated path: write to disk and update manifest ---
+
     # Write JSONL file to sessions directory
     sessions_dir = current_app.sessions_dir
     file_path = (sessions_dir / filename).resolve()
@@ -87,17 +108,6 @@ def upload_session():
             jsonify({"status": "error", "message": f"Session '{session_id}' already exists"}),
             400,
         )
-
-    # Build manifest entry
-    tags = [t.strip() for t in tags_raw.split(",") if t.strip()] if tags_raw else []
-    entry = {
-        "id": session_id,
-        "title": title,
-        "description": description,
-        "file": filename,
-        "beat_count": len(result["beats"]),
-        "tags": tags,
-    }
 
     # Update manifest on disk (atomic write via temp file + rename)
     manifest_path = sessions_dir / "manifest.json"

--- a/app/services/session_cache.py
+++ b/app/services/session_cache.py
@@ -6,6 +6,7 @@ so the API can serve them without re-parsing on every request.
 
 import json
 import logging
+import time
 from pathlib import Path
 
 from app.services.annotation_store import AnnotationStore
@@ -22,6 +23,7 @@ class SessionCache:
     def __init__(self):
         self._manifest = []
         self._parsed = {}
+        self._ephemeral = {}  # {session_id: {"data": {...}, "created_at": float}}
 
     def load(self, sessions_dir=None, debug=False):
         """Parse all curated sessions from disk into memory.
@@ -82,7 +84,13 @@ class SessionCache:
 
     def get_session(self, session_id):
         """Return pre-parsed session data, or None if not found."""
-        return self._parsed.get(session_id)
+        data = self._parsed.get(session_id)
+        if data is not None:
+            return data
+        ephemeral = self._ephemeral.get(session_id)
+        if ephemeral is not None:
+            return ephemeral["data"]
+        return None
 
     def update_annotations(self, session_id, annotations):
         """Update cached annotations for a session without full reload."""
@@ -99,3 +107,25 @@ class SessionCache:
             "errors": 0,
             "annotations": annotations,
         }
+
+    def add_ephemeral(self, session_id, entry, beats):
+        """Add an ephemeral session (memory-only, not in manifest)."""
+        self._ephemeral[session_id] = {
+            "data": {
+                "title": entry.get("title", session_id),
+                "beats": beats,
+                "errors": 0,
+                "annotations": None,
+            },
+            "created_at": time.time(),
+        }
+
+    def sweep_ephemeral(self, ttl):
+        """Remove ephemeral sessions older than ttl seconds."""
+        now = time.time()
+        expired = [
+            sid for sid, rec in self._ephemeral.items()
+            if now - rec["created_at"] > ttl
+        ]
+        for sid in expired:
+            del self._ephemeral[sid]

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -56,10 +56,24 @@ function clawbackApp() {
         _tourRect: null,
         _tourResizeHandler: null,
 
+        _deepLinkId: null,
+        _deepLinkAutoplay: false,
+
         /** Called by Alpine.js on component initialization. */
         init() {
             this.fetchConfig();
+            this._checkDeepLink();
             this.fetchSessions();
+        },
+
+        /** Check URL for deep-link parameters (?session=ID&autoplay=true). */
+        _checkDeepLink() {
+            var params = new URLSearchParams(window.location.search);
+            var sessionId = params.get("session");
+            if (sessionId) {
+                this._deepLinkId = sessionId;
+                this._deepLinkAutoplay = params.get("autoplay") === "true";
+            }
         },
 
         /** Fetch server configuration (e.g. read-only mode). */
@@ -164,18 +178,28 @@ function clawbackApp() {
                 .then(function (data) {
                     this.sessions = data.sessions || [];
                     this.loadingSessions = false;
+                    this._handleDeepLink();
                 }.bind(this))
                 .catch(function () {
                     this.sessions = [];
                     this.loadingSessions = false;
+                    this._handleDeepLink();
                 }.bind(this));
+        },
+
+        /** If a deep-link session ID is pending, load it now. */
+        _handleDeepLink() {
+            if (!this._deepLinkId) return;
+            var id = this._deepLinkId;
+            this._deepLinkId = null;
+            this.loadSession({ id: id });
         },
 
         /** Load a curated session by fetching its beats from the API. */
         loadSession(session) {
             this.loadingSession = true;
             this.uploadError = "";
-            fetch("/api/sessions/" + session.id)
+            fetch("/api/sessions/" + encodeURIComponent(session.id))
                 .then(function (r) {
                     if (!r.ok) throw new Error("Failed to load session");
                     return r.json();
@@ -183,9 +207,14 @@ function clawbackApp() {
                 .then(function (data) {
                     this.loadingSession = false;
                     this.startPlayback(data.beats, data.title || session.title, data.annotations);
+                    if (this._deepLinkAutoplay) {
+                        this._deepLinkAutoplay = false;
+                        this.togglePlay();
+                    }
                 }.bind(this))
                 .catch(function (err) {
                     this.loadingSession = false;
+                    this._deepLinkAutoplay = false;
                     this.uploadError = "Failed to load session: " + err.message;
                 }.bind(this));
         },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       # - CLAWBACK_SECRET=your-secret-here
       # Uncomment to disable editing and uploads (viewer-only mode):
       # - CLAWBACK_READ_ONLY=true
+      # Uncomment to set ephemeral session TTL in seconds (default: 14400 = 4 hours):
+      # - CLAWBACK_EPHEMERAL_TTL=14400
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:${PORT:-8080}/health')"]
       interval: 30s

--- a/tests/unit/js/test_app.js
+++ b/tests/unit/js/test_app.js
@@ -86,11 +86,12 @@ global.document = {
     querySelector: function () { return null; },
 };
 
-// window mock for resize event handling
+// window mock for resize event handling and location
 var _windowListeners = {};
 global.window = {
     innerWidth: 1280,
     innerHeight: 800,
+    location: { search: "" },
     addEventListener: function (evt, fn) {
         if (!_windowListeners[evt]) _windowListeners[evt] = [];
         _windowListeners[evt].push(fn);
@@ -2853,6 +2854,48 @@ test("openUploadForm is a no-op when readOnly is true", function () {
     app.readOnly = true;
     app.openUploadForm(makeFileEvent(makeFakeFile()));
     assert.equal(app._uploadForm, null, "upload form must not open in read-only mode");
+});
+
+// ---------------------------------------------------------------------------
+// Deep-link tests
+// ---------------------------------------------------------------------------
+
+test("_checkDeepLink sets _deepLinkId from query param", function () {
+    var app = makeApp(5);
+    window.location.search = "?session=my-session&autoplay=true";
+    app._checkDeepLink();
+    assert.equal(app._deepLinkId, "my-session");
+    assert.equal(app._deepLinkAutoplay, true);
+    window.location.search = "";
+});
+
+test("_checkDeepLink ignores empty query params", function () {
+    var app = makeApp(5);
+    window.location.search = "";
+    app._checkDeepLink();
+    assert.equal(app._deepLinkId, null);
+    assert.equal(app._deepLinkAutoplay, false);
+    window.location.search = "";
+});
+
+test("_handleDeepLink calls loadSession when _deepLinkId is set", function () {
+    var app = makeApp(5);
+    app.readOnly = false;
+    var loadedId = null;
+    app.loadSession = function (session) { loadedId = session.id; };
+    app._deepLinkId = "test-session";
+    app._handleDeepLink();
+    assert.equal(loadedId, "test-session");
+    assert.equal(app._deepLinkId, null, "_deepLinkId should be cleared after use");
+});
+
+test("_handleDeepLink does nothing when _deepLinkId is null", function () {
+    var app = makeApp(5);
+    var loadCalled = false;
+    app.loadSession = function () { loadCalled = true; };
+    app._deepLinkId = null;
+    app._handleDeepLink();
+    assert.equal(loadCalled, false);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,9 +1,11 @@
 import io
 import json
+import time
 
 import pytest
 
 from app import create_app
+from app.services.session_cache import SessionCache
 
 
 @pytest.fixture()
@@ -395,3 +397,134 @@ def test_upload_allowed_when_not_read_only(tmp_client):
         "/api/sessions/upload", data=data, content_type="multipart/form-data",
     )
     assert response.status_code == 201
+
+
+# --- Ephemeral upload tests ---
+
+_VALID_JSONL = (
+    '{"type":"user","message":{"content":"hello"},'
+    '"uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T00:00:00Z"}\n'
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]},'
+    '"uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T00:00:01Z"}\n'
+)
+
+
+def _ephemeral_upload(client, title="Ephemeral Session", ephemeral="true"):
+    """Helper to upload with the ephemeral flag."""
+    data = {
+        "file": (io.BytesIO(_VALID_JSONL.encode()), "eph.jsonl"),
+        "title": title,
+        "ephemeral": ephemeral,
+    }
+    return client.post(
+        "/api/sessions/upload", data=data, content_type="multipart/form-data",
+    )
+
+
+def test_upload_ephemeral_returns_201(tmp_client):
+    """Ephemeral upload succeeds and returns session entry."""
+    response = _ephemeral_upload(tmp_client)
+    assert response.status_code == 201
+    assert response.json["status"] == "ok"
+    assert response.json["session"]["id"] == "ephemeral-session"
+
+
+def test_upload_ephemeral_not_in_session_list(tmp_client):
+    """Ephemeral session does not appear in GET /api/sessions."""
+    _ephemeral_upload(tmp_client)
+    response = tmp_client.get("/api/sessions")
+    ids = [s["id"] for s in response.json["sessions"]]
+    assert "ephemeral-session" not in ids
+
+
+def test_upload_ephemeral_accessible_by_id(tmp_client):
+    """Ephemeral session is loadable via GET /api/sessions/<id>."""
+    _ephemeral_upload(tmp_client)
+    response = tmp_client.get("/api/sessions/ephemeral-session")
+    assert response.status_code == 200
+    assert len(response.json["beats"]) > 0
+    assert response.json["title"] == "Ephemeral Session"
+
+
+def test_upload_ephemeral_no_disk_write(tmp_client, tmp_path):
+    """Ephemeral upload does not write .jsonl to disk."""
+    # tmp_client uses tmp_path as sessions_dir from the fixture
+    _ephemeral_upload(tmp_client)
+    jsonl_files = list(tmp_path.glob("ephemeral*.jsonl"))
+    assert len(jsonl_files) == 0
+
+
+def test_upload_ephemeral_no_manifest_update(tmp_client, tmp_path):
+    """Ephemeral upload does not modify manifest.json."""
+    manifest_before = (tmp_path / "manifest.json").read_text()
+    _ephemeral_upload(tmp_client)
+    manifest_after = (tmp_path / "manifest.json").read_text()
+    assert manifest_before == manifest_after
+
+
+def test_upload_ephemeral_allowed_in_read_only(tmp_path):
+    """Ephemeral upload succeeds even when CLAWBACK_READ_ONLY=true."""
+    (tmp_path / "manifest.json").write_text("[]")
+    app = create_app({
+        "TESTING": True, "CLAWBACK_READ_ONLY": True,
+        "SESSIONS_DIR": str(tmp_path),
+    })
+    client = app.test_client()
+    response = _ephemeral_upload(client)
+    assert response.status_code == 201
+
+
+def test_upload_curated_blocked_in_read_only(tmp_path):
+    """Curated (non-ephemeral) upload still returns 403 in read-only mode."""
+    (tmp_path / "manifest.json").write_text("[]")
+    app = create_app({
+        "TESTING": True, "CLAWBACK_READ_ONLY": True,
+        "SESSIONS_DIR": str(tmp_path),
+    })
+    client = app.test_client()
+    data = {
+        "file": (io.BytesIO(_VALID_JSONL.encode()), "test.jsonl"),
+        "title": "Curated Session",
+    }
+    response = client.post(
+        "/api/sessions/upload", data=data, content_type="multipart/form-data",
+    )
+    assert response.status_code == 403
+
+
+def test_upload_default_is_not_ephemeral(tmp_client, tmp_path):
+    """Upload without ephemeral field writes to disk (backwards compat)."""
+    data = {
+        "file": (io.BytesIO(_VALID_JSONL.encode()), "test.jsonl"),
+        "title": "Persisted Upload",
+    }
+    tmp_client.post(
+        "/api/sessions/upload", data=data, content_type="multipart/form-data",
+    )
+    assert (tmp_path / "persisted-upload.jsonl").exists()
+
+
+def test_upload_ephemeral_duplicate_id_rejected(tmp_client):
+    """Duplicate ID across ephemeral+curated returns 400."""
+    _ephemeral_upload(tmp_client, title="Ephemeral Dup")
+    response = _ephemeral_upload(tmp_client, title="Ephemeral Dup")
+    assert response.status_code == 400
+    assert "already exists" in response.json["message"]
+
+
+def test_sweep_ephemeral_removes_expired(tmp_path):
+    """sweep_ephemeral() removes sessions past TTL."""
+    cache = SessionCache()
+    cache.add_ephemeral("old", {"title": "old"}, [{"id": 1}])
+    # Backdate the created_at
+    cache._ephemeral["old"]["created_at"] = time.time() - 10000
+    cache.sweep_ephemeral(5000)
+    assert cache.get_session("old") is None
+
+
+def test_sweep_ephemeral_keeps_fresh(tmp_path):
+    """sweep_ephemeral() preserves sessions within TTL."""
+    cache = SessionCache()
+    cache.add_ephemeral("fresh", {"title": "fresh"}, [{"id": 1}])
+    cache.sweep_ephemeral(5000)
+    assert cache.get_session("fresh") is not None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -19,3 +19,15 @@ def test_read_only_false_via_factory():
     """CLAWBACK_READ_ONLY=False is respected via config override."""
     app = create_app({"TESTING": True, "CLAWBACK_READ_ONLY": False})
     assert app.config["CLAWBACK_READ_ONLY"] is False
+
+
+def test_ephemeral_ttl_config_default():
+    """CLAWBACK_EPHEMERAL_TTL defaults to 14400 seconds."""
+    app = create_app({"TESTING": True})
+    assert app.config["CLAWBACK_EPHEMERAL_TTL"] == 14400
+
+
+def test_ephemeral_ttl_config_custom():
+    """CLAWBACK_EPHEMERAL_TTL is configurable via config override."""
+    app = create_app({"TESTING": True, "CLAWBACK_EPHEMERAL_TTL": 3600})
+    assert app.config["CLAWBACK_EPHEMERAL_TTL"] == 3600


### PR DESCRIPTION
## Summary

Add ephemeral (memory-only) session uploads and URL-based deep linking with autoplay, enabling external tools to programmatically upload a session file and generate a one-click playback link for users.

## Changes

- **Ephemeral upload path**: `POST /api/sessions/upload` accepts `ephemeral=true` form field — parses and caches in memory without writing to disk or updating manifest. Sessions auto-expire via configurable TTL (default 4h), swept lazily on next ephemeral upload.
- **Read-only bypass**: Ephemeral uploads succeed even when `CLAWBACK_READ_ONLY=true` (they don't modify curated content)
- **Deep-link query params**: `?session=<id>&autoplay=true` skips the picker and loads/plays a session directly
- **URL encoding**: Session IDs in fetch paths are now `encodeURIComponent`-encoded
- **Config table gap**: Added missing `CLAWBACK_READ_ONLY` entry to README configuration table

## Linked Issues

Closes #108

## Test Plan

- 13 new Python tests: ephemeral upload (201, not in list, accessible by ID, no disk write, no manifest update, read-only allowed, curated still blocked, default not ephemeral, duplicate rejected), sweep (removes expired, keeps fresh), config (default TTL, custom TTL)
- 4 new JS tests: deep-link parsing, handling, no-op on null
- Full suite: 232 JS + 131 Python = 363 tests, all passing
- `ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)