### PR TITLE
feat(api): multi-worker safe cache with disk-backed ephemeral sessions (#112)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ __marimo__/
 # Claude Code session state
 .claude/
 Docs/plan.md
+
+# Ephemeral sessions (temporary, not curated)
+sessions/ephemeral/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ EXPOSE ${PORT}
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT}/health')"
 
-CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:${PORT} --workers 2 'app:create_app()'"]
+# IMPORTANT: Keep workers at 1. The ephemeral session startup sweep in
+# create_app() is not safe with concurrent workers. Disk fallback handles
+# cross-worker cache misses if workers is ever increased.
+CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:${PORT} --workers 1 'app:create_app()'"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,8 +25,19 @@ def create_app(config=None):
     sessions_dir = Path(sessions_dir) if sessions_dir else _DEFAULT_SESSIONS_DIR
     app.sessions_dir = sessions_dir
 
-    # Annotation store for reading/writing sidecar files
+    # Ephemeral sessions directory — sibling to curated, cleared on startup
+    ephemeral_dir = config.get("EPHEMERAL_DIR") if config else None
+    ephemeral_dir = Path(ephemeral_dir) if ephemeral_dir else sessions_dir.parent / "ephemeral"
+    ephemeral_dir.mkdir(parents=True, exist_ok=True)
+    for f in ephemeral_dir.glob("*.jsonl"):
+        f.unlink()
+    for f in ephemeral_dir.glob("*-annotations.json"):
+        f.unlink()
+    app.ephemeral_dir = ephemeral_dir
+
+    # Annotation stores for curated and ephemeral sessions
     app.annotation_store = AnnotationStore(sessions_dir)
+    app.ephemeral_annotation_store = AnnotationStore(ephemeral_dir)
 
     # Pre-parse curated sessions at startup
     cache = SessionCache()
@@ -34,6 +45,7 @@ def create_app(config=None):
         sessions_dir=str(sessions_dir),
         debug=app.config.get("DEBUG", False),
     )
+    cache.set_directories(sessions_dir, ephemeral_dir)
     app.session_cache = cache
 
     from app.routes import register_blueprints

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -73,6 +73,22 @@ def upload_session():
             400,
         )
 
+    # Parse optional annotations
+    annotations = None
+    annotations_raw = request.form.get("annotations", "").strip()
+    if annotations_raw:
+        try:
+            annotations = json.loads(annotations_raw)
+        except (json.JSONDecodeError, ValueError):
+            return jsonify({"status": "error", "message": "Invalid annotations JSON"}), 400
+        validate_store = (
+            current_app.ephemeral_annotation_store if ephemeral
+            else current_app.annotation_store
+        )
+        errors = validate_store.validate(annotations)
+        if errors:
+            return jsonify({"status": "error", "errors": errors}), 400
+
     # Build manifest entry
     tags = [t.strip() for t in tags_raw.split(",") if t.strip()] if tags_raw else []
     entry = {
@@ -85,10 +101,18 @@ def upload_session():
     }
 
     if ephemeral:
-        # Memory-only: no disk write, no manifest update
+        # Write to ephemeral dir on disk, not curated
+        eph_dir = current_app.ephemeral_dir
+        eph_path = (eph_dir / filename).resolve()
+        if not _is_path_within(eph_path, eph_dir):
+            return jsonify({"status": "error", "message": "Invalid title"}), 400
+        with open(eph_path, "w") as f:
+            f.write(content)
+        if annotations:
+            current_app.ephemeral_annotation_store.save(session_id, annotations)
         cache = current_app.session_cache
         cache.sweep_ephemeral(current_app.config["CLAWBACK_EPHEMERAL_TTL"])
-        cache.add_ephemeral(session_id, entry, result["beats"])
+        cache.add_ephemeral(session_id, entry, result["beats"], annotations=annotations)
         return jsonify({"status": "ok", "session": entry}), 201
 
     # --- Curated path: write to disk and update manifest ---
@@ -138,9 +162,13 @@ def upload_session():
         os.unlink(tmp_name)
         raise
 
+    # Save annotations sidecar if provided
+    if annotations:
+        current_app.annotation_store.save(session_id, annotations)
+
     # Add to in-memory cache
     current_app.session_cache.add_session(
-        session_id, entry, result["beats"]
+        session_id, entry, result["beats"], annotations=annotations,
     )
 
     return jsonify({"status": "ok", "session": entry}), 201

--- a/app/services/session_cache.py
+++ b/app/services/session_cache.py
@@ -24,6 +24,13 @@ class SessionCache:
         self._manifest = []
         self._parsed = {}
         self._ephemeral = {}  # {session_id: {"data": {...}, "created_at": float}}
+        self._sessions_dir = None
+        self._ephemeral_dir = None
+
+    def set_directories(self, sessions_dir, ephemeral_dir):
+        """Set directory paths for disk fallback lookups."""
+        self._sessions_dir = Path(sessions_dir) if sessions_dir else None
+        self._ephemeral_dir = Path(ephemeral_dir) if ephemeral_dir else None
 
     def load(self, sessions_dir=None, debug=False):
         """Parse all curated sessions from disk into memory.
@@ -83,14 +90,51 @@ class SessionCache:
         return self._manifest
 
     def get_session(self, session_id):
-        """Return pre-parsed session data, or None if not found."""
+        """Return pre-parsed session data, or None if not found.
+
+        Checks in-memory caches first, then falls back to disk for
+        cross-worker discovery of recently uploaded sessions.
+        """
         data = self._parsed.get(session_id)
         if data is not None:
             return data
         ephemeral = self._ephemeral.get(session_id)
         if ephemeral is not None:
             return ephemeral["data"]
+        # Disk fallback — curated
+        if self._sessions_dir:
+            data = self._try_load_from_disk(session_id, self._sessions_dir)
+            if data is not None:
+                self._parsed[session_id] = data
+                return data
+        # Disk fallback — ephemeral
+        if self._ephemeral_dir:
+            data = self._try_load_from_disk(session_id, self._ephemeral_dir)
+            if data is not None:
+                self._ephemeral[session_id] = {
+                    "data": data,
+                    "created_at": time.time(),
+                }
+                return data
         return None
+
+    def _try_load_from_disk(self, session_id, directory):
+        """Attempt to load a session from disk. Returns parsed data or None."""
+        file_path = directory / f"{session_id}.jsonl"
+        if not file_path.exists():
+            return None
+        try:
+            result = parse_session(file_path.read_text())
+            annotations = AnnotationStore(directory).load(session_id)
+            return {
+                "title": session_id,
+                "beats": result["beats"],
+                "errors": result.get("errors", 0),
+                "annotations": annotations,
+            }
+        except Exception:
+            logger.warning("Failed to load session %s from disk", session_id)
+            return None
 
     def update_annotations(self, session_id, annotations):
         """Update cached annotations for a session without full reload."""
@@ -108,20 +152,20 @@ class SessionCache:
             "annotations": annotations,
         }
 
-    def add_ephemeral(self, session_id, entry, beats):
+    def add_ephemeral(self, session_id, entry, beats, annotations=None):
         """Add an ephemeral session (memory-only, not in manifest)."""
         self._ephemeral[session_id] = {
             "data": {
                 "title": entry.get("title", session_id),
                 "beats": beats,
                 "errors": 0,
-                "annotations": None,
+                "annotations": annotations,
             },
             "created_at": time.time(),
         }
 
     def sweep_ephemeral(self, ttl):
-        """Remove ephemeral sessions older than ttl seconds."""
+        """Remove ephemeral sessions older than ttl seconds (memory + disk)."""
         now = time.time()
         expired = [
             sid for sid, rec in self._ephemeral.items()
@@ -129,3 +173,19 @@ class SessionCache:
         ]
         for sid in expired:
             del self._ephemeral[sid]
+            if self._ephemeral_dir:
+                (self._ephemeral_dir / f"{sid}.jsonl").unlink(missing_ok=True)
+                (self._ephemeral_dir / f"{sid}-annotations.json").unlink(missing_ok=True)
+        # Also sweep disk-only orphans (written by other workers, never loaded)
+        if self._ephemeral_dir:
+            cutoff = now - ttl
+            for p in self._ephemeral_dir.glob("*.jsonl"):
+                try:
+                    if p.stat().st_mtime < cutoff:
+                        sid = p.stem
+                        p.unlink(missing_ok=True)
+                        (self._ephemeral_dir / f"{sid}-annotations.json").unlink(
+                            missing_ok=True
+                        )
+                except OSError:
+                    pass

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -27,7 +27,13 @@ def tmp_client(tmp_path):
     ]
     (tmp_path / "manifest.json").write_text(json.dumps(manifest))
 
-    app = create_app({"TESTING": True, "DEBUG": True, "SESSIONS_DIR": str(tmp_path)})
+    eph_dir = tmp_path / "ephemeral"
+    eph_dir.mkdir()
+    app = create_app({
+        "TESTING": True, "DEBUG": True,
+        "SESSIONS_DIR": str(tmp_path),
+        "EPHEMERAL_DIR": str(eph_dir),
+    })
     return app.test_client()
 
 
@@ -336,6 +342,7 @@ def test_annotations_put_blocked_when_read_only(tmp_path):
     app = create_app({
         "TESTING": True, "CLAWBACK_READ_ONLY": True,
         "SESSIONS_DIR": str(tmp_path),
+        "EPHEMERAL_DIR": str(tmp_path / "ephemeral"),
     })
     client = app.test_client()
     response = client.put(
@@ -352,6 +359,7 @@ def test_upload_blocked_when_read_only(tmp_path):
     app = create_app({
         "TESTING": True, "CLAWBACK_READ_ONLY": True,
         "SESSIONS_DIR": str(tmp_path),
+        "EPHEMERAL_DIR": str(tmp_path / "ephemeral"),
     })
     client = app.test_client()
     jsonl = (
@@ -446,10 +454,10 @@ def test_upload_ephemeral_accessible_by_id(tmp_client):
     assert response.json["title"] == "Ephemeral Session"
 
 
-def test_upload_ephemeral_no_disk_write(tmp_client, tmp_path):
-    """Ephemeral upload does not write .jsonl to disk."""
-    # tmp_client uses tmp_path as sessions_dir from the fixture
+def test_upload_ephemeral_no_curated_disk_write(tmp_client, tmp_path):
+    """Ephemeral upload does not write .jsonl to curated dir."""
     _ephemeral_upload(tmp_client)
+    # Not in curated dir (tmp_path itself)
     jsonl_files = list(tmp_path.glob("ephemeral*.jsonl"))
     assert len(jsonl_files) == 0
 
@@ -468,6 +476,7 @@ def test_upload_ephemeral_allowed_in_read_only(tmp_path):
     app = create_app({
         "TESTING": True, "CLAWBACK_READ_ONLY": True,
         "SESSIONS_DIR": str(tmp_path),
+        "EPHEMERAL_DIR": str(tmp_path / "ephemeral"),
     })
     client = app.test_client()
     response = _ephemeral_upload(client)
@@ -480,6 +489,7 @@ def test_upload_curated_blocked_in_read_only(tmp_path):
     app = create_app({
         "TESTING": True, "CLAWBACK_READ_ONLY": True,
         "SESSIONS_DIR": str(tmp_path),
+        "EPHEMERAL_DIR": str(tmp_path / "ephemeral"),
     })
     client = app.test_client()
     data = {
@@ -528,3 +538,125 @@ def test_sweep_ephemeral_keeps_fresh(tmp_path):
     cache.add_ephemeral("fresh", {"title": "fresh"}, [{"id": 1}])
     cache.sweep_ephemeral(5000)
     assert cache.get_session("fresh") is not None
+
+
+# --- Ephemeral disk write tests ---
+
+
+def test_ephemeral_upload_writes_to_disk(tmp_client, tmp_path):
+    """Ephemeral upload creates .jsonl in ephemeral dir."""
+    _ephemeral_upload(tmp_client)
+    eph_dir = tmp_path / "ephemeral"
+    assert (eph_dir / "ephemeral-session.jsonl").exists()
+
+
+def test_ephemeral_not_in_curated_dir(tmp_client, tmp_path):
+    """Ephemeral file is in ephemeral dir, not curated."""
+    _ephemeral_upload(tmp_client)
+    assert not (tmp_path / "ephemeral-session.jsonl").exists()
+    assert (tmp_path / "ephemeral" / "ephemeral-session.jsonl").exists()
+
+
+# --- Upload with annotations tests ---
+
+
+def test_upload_with_annotations(tmp_client):
+    """Upload with annotations field saves annotations."""
+    annotations = json.dumps({
+        "session_id": "annotated-upload",
+        "sections": [],
+        "callouts": [
+            {"id": "cal-1", "after_beat": 0, "style": "note", "content": "Hello"}
+        ],
+        "artifacts": [],
+    })
+    data = {
+        "file": (io.BytesIO(_VALID_JSONL.encode()), "test.jsonl"),
+        "title": "Annotated Upload",
+        "annotations": annotations,
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload", data=data, content_type="multipart/form-data",
+    )
+    assert response.status_code == 201
+
+    # Verify annotations are accessible
+    response = tmp_client.get("/api/sessions/annotated-upload")
+    assert response.status_code == 200
+    assert response.json["annotations"] is not None
+    assert len(response.json["annotations"]["callouts"]) == 1
+
+
+def test_upload_with_invalid_annotations(tmp_client):
+    """Upload with bad annotations JSON returns 400."""
+    data = {
+        "file": (io.BytesIO(_VALID_JSONL.encode()), "test.jsonl"),
+        "title": "Bad Annotations",
+        "annotations": "not valid json{{{",
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload", data=data, content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert "Invalid annotations" in response.json["message"]
+
+
+def test_upload_without_annotations_unchanged(tmp_client):
+    """Upload without annotations field works as before."""
+    data = {
+        "file": (io.BytesIO(_VALID_JSONL.encode()), "test.jsonl"),
+        "title": "No Annotations",
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload", data=data, content_type="multipart/form-data",
+    )
+    assert response.status_code == 201
+    response = tmp_client.get("/api/sessions/no-annotations")
+    assert response.json["annotations"] is None
+
+
+def test_ephemeral_upload_with_schema_invalid_annotations(tmp_client):
+    """Ephemeral upload with schema-invalid annotations returns 400."""
+    annotations = json.dumps({
+        "session_id": "x",
+        "sections": [],
+        "callouts": [
+            {"id": "c1", "after_beat": 0, "style": "INVALID_STYLE", "content": "hi"}
+        ],
+        "artifacts": [],
+    })
+    data = {
+        "file": (io.BytesIO(_VALID_JSONL.encode()), "test.jsonl"),
+        "title": "Bad Schema Eph",
+        "ephemeral": "true",
+        "annotations": annotations,
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload", data=data, content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert "errors" in response.json
+
+
+def test_ephemeral_upload_with_annotations(tmp_client, tmp_path):
+    """Ephemeral upload saves annotations sidecar."""
+    annotations = json.dumps({
+        "session_id": "eph-annotated",
+        "sections": [],
+        "callouts": [],
+        "artifacts": [],
+    })
+    data = {
+        "file": (io.BytesIO(_VALID_JSONL.encode()), "test.jsonl"),
+        "title": "Eph Annotated",
+        "ephemeral": "true",
+        "annotations": annotations,
+    }
+    response = tmp_client.post(
+        "/api/sessions/upload", data=data, content_type="multipart/form-data",
+    )
+    assert response.status_code == 201
+    eph_dir = tmp_path / "ephemeral"
+    assert (eph_dir / "eph-annotated-annotations.json").exists()
+    response = tmp_client.get("/api/sessions/eph-annotated")
+    assert response.json["annotations"] is not None

--- a/tests/unit/test_session_cache.py
+++ b/tests/unit/test_session_cache.py
@@ -203,3 +203,103 @@ def test_add_session_with_annotations(cache):
     data = cache.get_session("annotated")
     assert data["annotations"] is not None
     assert data["annotations"]["session_id"] == "annotated"
+
+
+# --- Disk fallback tests ---
+
+_MINIMAL_JSONL = (
+    '{"type":"user","message":{"content":"hello"},'
+    '"uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T00:00:00Z"}\n'
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]},'
+    '"uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T00:00:01Z"}\n'
+)
+
+
+def test_get_session_disk_fallback_curated(tmp_path):
+    """Cache miss loads curated session from disk."""
+    # Write session file but don't add to cache
+    (tmp_path / "disk-session.jsonl").write_text(_MINIMAL_JSONL)
+    (tmp_path / "manifest.json").write_text("[]")
+
+    c = SessionCache()
+    c.load(str(tmp_path))
+    c.set_directories(tmp_path, tmp_path / "ephemeral")
+
+    # Not in memory
+    assert "disk-session" not in c._parsed
+    # But disk fallback finds it
+    data = c.get_session("disk-session")
+    assert data is not None
+    assert len(data["beats"]) > 0
+    # Now cached in memory
+    assert "disk-session" in c._parsed
+
+
+def test_get_session_disk_fallback_ephemeral(tmp_path):
+    """Cache miss loads ephemeral session from disk."""
+    eph_dir = tmp_path / "ephemeral"
+    eph_dir.mkdir()
+    (eph_dir / "eph-session.jsonl").write_text(_MINIMAL_JSONL)
+    (tmp_path / "manifest.json").write_text("[]")
+
+    c = SessionCache()
+    c.load(str(tmp_path))
+    c.set_directories(tmp_path, eph_dir)
+
+    data = c.get_session("eph-session")
+    assert data is not None
+    assert len(data["beats"]) > 0
+    assert "eph-session" in c._ephemeral
+
+
+def test_get_session_disk_fallback_not_found(tmp_path):
+    """Disk fallback returns None when file doesn't exist."""
+    eph_dir = tmp_path / "ephemeral"
+    eph_dir.mkdir()
+    (tmp_path / "manifest.json").write_text("[]")
+
+    c = SessionCache()
+    c.load(str(tmp_path))
+    c.set_directories(tmp_path, eph_dir)
+
+    assert c.get_session("nonexistent") is None
+
+
+def test_sweep_ephemeral_deletes_files(tmp_path):
+    """TTL sweep removes .jsonl and sidecar from disk."""
+    import time
+
+    eph_dir = tmp_path / "ephemeral"
+    eph_dir.mkdir()
+    (eph_dir / "old-session.jsonl").write_text(_MINIMAL_JSONL)
+    (eph_dir / "old-session-annotations.json").write_text("{}")
+
+    c = SessionCache()
+    c.set_directories(tmp_path, eph_dir)
+    c.add_ephemeral("old-session", {"title": "old"}, [{"id": 1}])
+    c._ephemeral["old-session"]["created_at"] = time.time() - 10000
+
+    c.sweep_ephemeral(5000)
+
+    assert c.get_session("old-session") is None
+    assert not (eph_dir / "old-session.jsonl").exists()
+    assert not (eph_dir / "old-session-annotations.json").exists()
+
+
+def test_startup_clears_ephemeral_dir(tmp_path):
+    """App factory clears ephemeral dir on startup."""
+    from app import create_app
+
+    eph_dir = tmp_path / "ephemeral"
+    eph_dir.mkdir()
+    (eph_dir / "stale.jsonl").write_text(_MINIMAL_JSONL)
+    (eph_dir / "stale-annotations.json").write_text("{}")
+
+    create_app({
+        "TESTING": True,
+        "SESSIONS_DIR": str(tmp_path),
+        "EPHEMERAL_DIR": str(eph_dir),
+    })
+
+    assert not (eph_dir / "stale.jsonl").exists()
+    assert not (eph_dir / "stale-annotations.json").exists()


### PR DESCRIPTION
## Summary

Fixes a multi-worker cache coherence bug where gunicorn workers had independent SessionCache instances — sessions uploaded on one worker were invisible to another, causing 404s on annotation PUT and session GET.

## Changes

- **Disk fallback on cache miss**: `get_session()` checks both curated and ephemeral directories when in-memory lookup fails, parsing on demand and caching the result
- **Disk-backed ephemeral sessions**: Ephemeral uploads write `.jsonl` to `sessions/ephemeral/` instead of being memory-only. Directory cleared on startup. TTL sweep deletes expired files and scans disk for orphans
- **Annotations in upload**: Upload endpoint accepts optional `annotations` JSON field — validated and saved in the same request, eliminating the two-request race condition
- **Workers=1 default**: Dockerfile changed from `--workers 2` to `--workers 1` with explanatory comment
- **Defense in depth**: Path traversal guard on ephemeral writes, correct annotation store selection per upload type

## Linked Issues

Closes #112

## Test Plan

- 12 new Python tests: disk fallback (curated/ephemeral/not-found), sweep deletes files, startup clears dir, ephemeral disk write, not in curated dir, upload with/without/invalid/schema-invalid annotations, ephemeral with annotations
- Full suite: 518 JS + 143 Python = 661 tests, all passing
- Code review: 6 findings fixed (path traversal, store selection, workers doc, orphan sweep, API encapsulation, test gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)