### PR TITLE
feat(ui,api): collapse skill expansions + session DELETE endpoint

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -183,6 +183,69 @@ def get_session(session_id):
     return jsonify(data)
 
 
+@api_bp.route("/sessions/<session_id>", methods=["DELETE"])
+def delete_session(session_id):
+    """Delete a session — removes cache, manifest entry, and disk files.
+
+    Handles both curated and ephemeral sessions.
+    """
+    if current_app.config["CLAWBACK_READ_ONLY"]:
+        return jsonify({"status": "error", "message": "Read-only mode"}), 403
+
+    cache = current_app.session_cache
+    if cache.get_session(session_id) is None:
+        return jsonify({"status": "error", "message": "Session not found"}), 404
+
+    # Check if ephemeral before removing from cache (lookup disappears after delete)
+    is_ephemeral = session_id in cache._ephemeral
+
+    # Remove from in-memory cache and manifest
+    cache.delete_session(session_id)
+
+    if is_ephemeral:
+        # Ephemeral: remove from ephemeral dir
+        eph_dir = current_app.ephemeral_dir
+        eph_path = (eph_dir / f"{session_id}.jsonl").resolve()
+        if _is_path_within(eph_path, eph_dir) and eph_path.exists():
+            eph_path.unlink()
+        current_app.ephemeral_annotation_store.delete(session_id)
+    else:
+        # Curated: remove JSONL, annotations sidecar, and rewrite manifest
+        sessions_dir = current_app.sessions_dir
+        file_path = (sessions_dir / f"{session_id}.jsonl").resolve()
+        if _is_path_within(file_path, sessions_dir) and file_path.exists():
+            file_path.unlink()
+
+        current_app.annotation_store.delete(session_id)
+
+        # Rewrite manifest atomically
+        manifest_path = sessions_dir / "manifest.json"
+        if manifest_path.exists():
+            try:
+                with open(manifest_path) as f:
+                    manifest = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                manifest = []
+
+            manifest = [e for e in manifest if e.get("id") != session_id]
+
+            fd, tmp_name = tempfile.mkstemp(dir=str(sessions_dir), suffix=".json")
+            try:
+                import os
+
+                with open(fd, "w") as f:
+                    json.dump(manifest, f, indent=4)
+                    f.write("\n")
+                os.replace(tmp_name, str(manifest_path))
+            except Exception:
+                import os
+
+                os.unlink(tmp_name)
+                raise
+
+    return jsonify({"status": "ok"})
+
+
 @api_bp.route("/sessions/<session_id>/annotations", methods=["PUT"])
 def save_annotations(session_id):
     """Validate and save annotations for a curated session."""

--- a/app/services/annotation_store.py
+++ b/app/services/annotation_store.py
@@ -75,6 +75,14 @@ class AnnotationStore:
 
         logger.info("Saved annotations for session %s", session_id)
 
+    def delete(self, session_id):
+        """Remove the annotation sidecar file if it exists."""
+        try:
+            path = self._annotation_path(session_id)
+        except ValueError:
+            return
+        path.unlink(missing_ok=True)
+
     def validate(self, data):
         """Return a list of validation errors (empty if valid)."""
         errors = []

--- a/app/services/session_cache.py
+++ b/app/services/session_cache.py
@@ -142,6 +142,23 @@ class SessionCache:
             return
         self._parsed[session_id]["annotations"] = annotations
 
+    def delete_session(self, session_id):
+        """Remove a session from in-memory cache (and manifest for curated).
+
+        Handles both curated and ephemeral sessions.
+        Returns True if the session was found and removed, False otherwise.
+        Does NOT remove disk files — the caller handles that.
+        """
+        found = False
+        if session_id in self._parsed:
+            del self._parsed[session_id]
+            self._manifest = [e for e in self._manifest if e.get("id") != session_id]
+            found = True
+        if session_id in self._ephemeral:
+            del self._ephemeral[session_id]
+            found = True
+        return found
+
     def add_session(self, session_id, entry, beats, annotations=None):
         """Add a newly uploaded session to the cache without restart."""
         self._manifest.append(entry)

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -724,6 +724,80 @@ body {
 }
 
 /* -----------------------------------------------------------------------
+   Skill expansion cards (collapsed by default)
+   ----------------------------------------------------------------------- */
+.skill-card {
+    align-self: flex-end;
+    width: 80%;
+    background-color: var(--color-user-bubble);
+    border-radius: 12px;
+    animation: fadeSlideUp 0.3s ease-out;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    position: relative;
+}
+
+.skill-card__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.skill-card__header:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.skill-card__icon {
+    font-size: 1.1rem;
+    flex-shrink: 0;
+}
+
+.skill-card__summary {
+    flex: 1;
+    font-size: 0.875rem;
+    color: var(--color-text);
+}
+
+.skill-card__toggle {
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    padding: 4px 10px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color 0.2s, border-color 0.2s;
+}
+
+.skill-card__toggle:hover {
+    color: var(--color-text);
+    border-color: var(--color-text-muted);
+}
+
+.skill-card__body {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease-in-out;
+    font-family: var(--font-mono);
+    font-size: 0.8em;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+}
+
+.skill-card--expanded .skill-card__body {
+    padding: 0 16px 12px;
+    border-top: 1px solid var(--color-border);
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+/* -----------------------------------------------------------------------
    Callout annotation cards
    ----------------------------------------------------------------------- */
 .callout {

--- a/app/static/js/renderer.js
+++ b/app/static/js/renderer.js
@@ -105,6 +105,15 @@ function renderBeat(beat, container) {
         return null;
     }
 
+    // Detect and collapse skill file expansions (large user messages
+    // injected when a slash command loads its skill file into context)
+    if (beat.type === "user_message") {
+        var cleaned = _stripSystemTags(beat.content);
+        if (cleaned.startsWith("Base directory for this skill:")) {
+            return _renderSkillExpansion(beat, cleaned, container);
+        }
+    }
+
     const bubble = document.createElement("div");
     bubble.classList.add("bubble");
     bubble.dataset.beatId = String(beat.id);
@@ -204,6 +213,93 @@ function renderArtifactPanel(artifact, contentEl) {
             hljs.highlightElement(block);
         });
     }
+}
+
+// ---------------------------------------------------------------------------
+// Internal — skill expansion rendering (collapsed by default)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strips system-injected tags but preserves original whitespace/indentation.
+ * Lighter than _formatUserContent — used for detection and skill card body.
+ */
+function _stripSystemTags(text) {
+    if (!text) return "";
+    return text
+        .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
+        .replace(/<local-command-caveat>[\s\S]*?<\/local-command-caveat>/g, "")
+        .trim();
+}
+
+/**
+ * Renders a skill file expansion as a collapsed card instead of a full bubble.
+ * Extracts the skill name from the "Base directory" header line.
+ */
+function _renderSkillExpansion(beat, content, container) {
+    var firstLine = content.split("\n")[0];
+    var pathMatch = firstLine.match(/Base directory for this skill:\s*(.+)/);
+    var skillPath = pathMatch ? pathMatch[1].trim() : "";
+    var skillName = skillPath.split("/").pop() || "unknown";
+
+    var card = document.createElement("div");
+    card.classList.add("skill-card", "skill-card--collapsed");
+    card.dataset.beatId = String(beat.id);
+
+    var header = document.createElement("div");
+    header.classList.add("skill-card__header");
+
+    var icon = document.createElement("span");
+    icon.classList.add("skill-card__icon");
+    icon.textContent = "\u2699";
+
+    var summary = document.createElement("span");
+    summary.classList.add("skill-card__summary");
+    summary.textContent = "Skill loaded: /" + skillName;
+
+    var toggleBtn = document.createElement("button");
+    toggleBtn.classList.add("skill-card__toggle");
+    toggleBtn.textContent = "\u25B6 Show";
+
+    header.appendChild(icon);
+    header.appendChild(summary);
+    header.appendChild(toggleBtn);
+
+    var body = document.createElement("div");
+    body.classList.add("skill-card__body");
+    body.textContent = content;
+
+    card.appendChild(header);
+    card.appendChild(body);
+
+    // Beat number metadata
+    var meta = document.createElement("span");
+    meta.classList.add("bubble__meta");
+    meta.textContent = "#" + (beat.id + 1);
+    card.appendChild(meta);
+
+    container.appendChild(card);
+
+    var expanded = false;
+    function toggle(e) {
+        if (e) e.stopPropagation();
+        expanded = !expanded;
+        if (expanded) {
+            card.classList.remove("skill-card--collapsed");
+            card.classList.add("skill-card--expanded");
+            body.style.maxHeight = body.scrollHeight + "px";
+            toggleBtn.textContent = "\u25BC Hide";
+        } else {
+            card.classList.remove("skill-card--expanded");
+            card.classList.add("skill-card--collapsed");
+            body.style.maxHeight = "0";
+            toggleBtn.textContent = "\u25B6 Show";
+        }
+    }
+
+    toggleBtn.addEventListener("click", toggle);
+    header.addEventListener("click", toggle);
+
+    return card;
 }
 
 // ---------------------------------------------------------------------------
@@ -498,5 +594,6 @@ if (typeof module !== "undefined" && module.exports) {
         resetGroups,
         renderArtifactPanel,
         _formatUserContent,
+        _stripSystemTags,
     };
 }

--- a/tests/unit/js/test_renderer.js
+++ b/tests/unit/js/test_renderer.js
@@ -104,6 +104,7 @@ const {
     resetGroups,
     renderArtifactPanel,
     _formatUserContent,
+    _stripSystemTags,
 } = require("../../../app/static/js/renderer.js");
 
 let passed = 0;
@@ -1372,6 +1373,171 @@ test("renderBeat skips empty formatted user message", () => {
     }), container);
     assert.equal(result, null, "should return null for empty formatted content");
     assert.equal(container.children.length, 0, "should not append any element");
+});
+
+// ---------------------------------------------------------------------------
+// _stripSystemTags
+// ---------------------------------------------------------------------------
+console.log("\n_stripSystemTags");
+
+test("strips system-reminder tags but preserves whitespace", () => {
+    const input = "line one\n  indented\n<system-reminder>hidden</system-reminder>\nlast";
+    const result = _stripSystemTags(input);
+    assert.ok(result.includes("  indented"), "should preserve leading spaces");
+    assert.ok(!result.includes("hidden"));
+});
+
+test("strips local-command-caveat tags", () => {
+    const input = "<local-command-caveat>caveat</local-command-caveat>\nreal content";
+    assert.equal(_stripSystemTags(input), "real content");
+});
+
+test("returns empty string for null", () => {
+    assert.equal(_stripSystemTags(null), "");
+});
+
+test("returns trimmed content for plain text", () => {
+    assert.equal(_stripSystemTags("  hello  "), "hello");
+});
+
+// ---------------------------------------------------------------------------
+// renderBeat — skill expansion cards
+// ---------------------------------------------------------------------------
+console.log("\nrenderBeat — skill expansion cards");
+
+test("renders skill expansion as collapsed card instead of bubble", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, {
+        type: "user_message",
+        content: "Base directory for this skill: /home/user/.claude/skills/ddd\n\n# DDD Skill\n\nLots of content here...",
+    });
+    const card = renderBeat(beat, container);
+    assert.ok(card, "should return an element");
+    assert.ok(card.classList.contains("skill-card"), "should be a skill-card");
+    assert.ok(card.classList.contains("skill-card--collapsed"), "should start collapsed");
+    assert.ok(!card.classList.contains("bubble"), "should NOT be a regular bubble");
+});
+
+test("skill card extracts skill name from path", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, {
+        type: "user_message",
+        content: "Base directory for this skill: /home/user/.claude/skills/precheck\n\nContent...",
+    });
+    const card = renderBeat(beat, container);
+    const header = card.children.find((c) => c.classList.contains("skill-card__header"));
+    const summary = header.children.find((c) => c.classList.contains("skill-card__summary"));
+    assert.ok(summary.textContent.includes("/precheck"), "should show skill name");
+});
+
+test("skill card has toggle button", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, {
+        type: "user_message",
+        content: "Base directory for this skill: /home/user/.claude/skills/ddd\n\nContent...",
+    });
+    const card = renderBeat(beat, container);
+    const header = card.children.find((c) => c.classList.contains("skill-card__header"));
+    const toggle = header.children.find((c) => c.classList.contains("skill-card__toggle"));
+    assert.ok(toggle, "should have toggle button");
+    assert.ok(toggle.textContent.includes("Show"), "should say Show when collapsed");
+});
+
+test("clicking skill card toggle expands it", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, {
+        type: "user_message",
+        content: "Base directory for this skill: /home/user/.claude/skills/ddd\n\nContent...",
+    });
+    const card = renderBeat(beat, container);
+    const header = card.children.find((c) => c.classList.contains("skill-card__header"));
+    const toggle = header.children.find((c) => c.classList.contains("skill-card__toggle"));
+
+    toggle.click();
+    assert.ok(card.classList.contains("skill-card--expanded"), "should be expanded");
+    assert.ok(!card.classList.contains("skill-card--collapsed"), "should not be collapsed");
+    assert.ok(toggle.textContent.includes("Hide"), "should say Hide when expanded");
+});
+
+test("clicking skill card toggle twice re-collapses it", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, {
+        type: "user_message",
+        content: "Base directory for this skill: /home/user/.claude/skills/ddd\n\nContent...",
+    });
+    const card = renderBeat(beat, container);
+    const header = card.children.find((c) => c.classList.contains("skill-card__header"));
+    const toggle = header.children.find((c) => c.classList.contains("skill-card__toggle"));
+
+    toggle.click();
+    toggle.click();
+    assert.ok(card.classList.contains("skill-card--collapsed"));
+    assert.ok(!card.classList.contains("skill-card--expanded"));
+});
+
+test("skill card sets data-beat-id", () => {
+    const container = makeContainer();
+    const beat = makeBeat(42, {
+        type: "user_message",
+        content: "Base directory for this skill: /home/user/.claude/skills/ddd\n\nContent...",
+    });
+    const card = renderBeat(beat, container);
+    assert.equal(card.dataset.beatId, "42");
+});
+
+test("skill card has beat number meta element", () => {
+    const container = makeContainer();
+    const beat = makeBeat(9, {
+        type: "user_message",
+        content: "Base directory for this skill: /home/user/.claude/skills/ddd\n\nContent...",
+    });
+    const card = renderBeat(beat, container);
+    const meta = card.children.find((c) => c.classList.contains("bubble__meta"));
+    assert.ok(meta, "should have meta element");
+    assert.equal(meta.textContent, "#10");
+});
+
+test("skill card can be removed via removeBeat", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, {
+        type: "user_message",
+        content: "Base directory for this skill: /home/user/.claude/skills/ddd\n\nContent...",
+    });
+    renderBeat(beat, container);
+    assert.equal(container.children.length, 1);
+    removeBeat({ id: 0 }, container);
+    assert.equal(container.children.length, 0);
+});
+
+test("skill card preserves full content in body", () => {
+    const container = makeContainer();
+    const content = "Base directory for this skill: /home/user/.claude/skills/ddd\n\n# DDD Skill\n\nLine 1\n  Indented line";
+    const beat = makeBeat(0, { type: "user_message", content: content });
+    const card = renderBeat(beat, container);
+    const body = card.children.find((c) => c.classList.contains("skill-card__body"));
+    assert.ok(body.textContent.includes("# DDD Skill"), "body should have full content");
+    assert.ok(body.textContent.includes("  Indented line"), "body should preserve indentation");
+});
+
+test("normal user message is NOT collapsed as skill card", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, {
+        type: "user_message",
+        content: "Please review this code for me",
+    });
+    const bubble = renderBeat(beat, container);
+    assert.ok(bubble.classList.contains("bubble--user"), "should be a normal bubble");
+    assert.ok(!bubble.classList.contains("skill-card"), "should NOT be a skill card");
+});
+
+test("skill detection ignores system-reminder wrapping", () => {
+    const container = makeContainer();
+    const beat = makeBeat(0, {
+        type: "user_message",
+        content: "<system-reminder>some injected stuff</system-reminder>Base directory for this skill: /home/user/.claude/skills/engage\n\nContent...",
+    });
+    const card = renderBeat(beat, container);
+    assert.ok(card.classList.contains("skill-card"), "should detect skill after stripping system tags");
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -660,3 +660,119 @@ def test_ephemeral_upload_with_annotations(tmp_client, tmp_path):
     assert (eph_dir / "eph-annotated-annotations.json").exists()
     response = tmp_client.get("/api/sessions/eph-annotated")
     assert response.json["annotations"] is not None
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/sessions/<session_id>
+# ---------------------------------------------------------------------------
+
+
+def test_delete_session_success(tmp_client, tmp_path):
+    """DELETE removes session from cache, manifest, and disk."""
+    # Verify session exists first
+    response = tmp_client.get("/api/sessions/test-session")
+    assert response.status_code == 200
+
+    response = tmp_client.delete("/api/sessions/test-session")
+    assert response.status_code == 200
+    assert response.json["status"] == "ok"
+
+    # Session no longer accessible
+    response = tmp_client.get("/api/sessions/test-session")
+    assert response.status_code == 404
+
+    # Session no longer in list
+    response = tmp_client.get("/api/sessions")
+    ids = [s["id"] for s in response.json["sessions"]]
+    assert "test-session" not in ids
+
+    # JSONL file removed from disk
+    assert not (tmp_path / "test-session.jsonl").exists()
+
+    # Manifest updated on disk
+    with open(tmp_path / "manifest.json") as f:
+        manifest = json.load(f)
+    ids = [e["id"] for e in manifest]
+    assert "test-session" not in ids
+
+
+def test_delete_session_404_unknown(tmp_client):
+    """DELETE returns 404 for non-existent session."""
+    response = tmp_client.delete("/api/sessions/nonexistent")
+    assert response.status_code == 404
+
+
+def test_delete_session_blocked_when_read_only(tmp_path):
+    """DELETE is blocked in read-only mode."""
+    jsonl = (
+        '{"type":"user","message":{"content":"hello"},'
+        '"uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T00:00:00Z"}\n'
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]},'
+        '"uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T00:00:01Z"}\n'
+    )
+    (tmp_path / "test-session.jsonl").write_text(jsonl)
+    manifest = [{"id": "test-session", "title": "Test", "file": "test-session.jsonl",
+                 "beat_count": 2, "description": "A test", "tags": []}]
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+    eph_dir = tmp_path / "ephemeral"
+    eph_dir.mkdir()
+    app = create_app({
+        "TESTING": True, "DEBUG": True,
+        "SESSIONS_DIR": str(tmp_path),
+        "EPHEMERAL_DIR": str(eph_dir),
+        "CLAWBACK_READ_ONLY": True,
+    })
+    client = app.test_client()
+    response = client.delete("/api/sessions/test-session")
+    assert response.status_code == 403
+
+
+def test_delete_removes_annotations_sidecar(tmp_client, tmp_path):
+    """DELETE removes the annotations sidecar file too."""
+    # Create annotations for test-session
+    ann = {"session_id": "test-session", "sections": [], "callouts": [], "artifacts": []}
+    response = tmp_client.put(
+        "/api/sessions/test-session/annotations",
+        data=json.dumps(ann),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert (tmp_path / "test-session-annotations.json").exists()
+
+    # Delete the session
+    response = tmp_client.delete("/api/sessions/test-session")
+    assert response.status_code == 200
+
+    # Annotations sidecar removed
+    assert not (tmp_path / "test-session-annotations.json").exists()
+
+
+def test_delete_ephemeral_session(tmp_client, tmp_path):
+    """DELETE removes ephemeral session from cache and disk."""
+    _ephemeral_upload(tmp_client)
+    # Verify it exists
+    response = tmp_client.get("/api/sessions/ephemeral-session")
+    assert response.status_code == 200
+
+    response = tmp_client.delete("/api/sessions/ephemeral-session")
+    assert response.status_code == 200
+    assert response.json["status"] == "ok"
+
+    # No longer accessible
+    response = tmp_client.get("/api/sessions/ephemeral-session")
+    assert response.status_code == 404
+
+    # Disk file removed
+    eph_dir = tmp_path / "ephemeral"
+    assert not (eph_dir / "ephemeral-session.jsonl").exists()
+
+
+def test_delete_ephemeral_does_not_touch_manifest(tmp_client, tmp_path):
+    """DELETE of ephemeral session leaves curated manifest unchanged."""
+    _ephemeral_upload(tmp_client)
+    manifest_before = (tmp_path / "manifest.json").read_text()
+
+    tmp_client.delete("/api/sessions/ephemeral-session")
+
+    manifest_after = (tmp_path / "manifest.json").read_text()
+    assert manifest_before == manifest_after

--- a/tests/unit/test_session_cache.py
+++ b/tests/unit/test_session_cache.py
@@ -303,3 +303,33 @@ def test_startup_clears_ephemeral_dir(tmp_path):
 
     assert not (eph_dir / "stale.jsonl").exists()
     assert not (eph_dir / "stale-annotations.json").exists()
+
+
+def test_delete_session(cache):
+    """delete_session removes from cache and manifest."""
+    sessions = cache.list_sessions()
+    first_id = sessions[0]["id"]
+    assert cache.get_session(first_id) is not None
+
+    result = cache.delete_session(first_id)
+    assert result is True
+    assert cache.get_session(first_id) is None
+    ids = [s["id"] for s in cache.list_sessions()]
+    assert first_id not in ids
+
+
+def test_delete_session_unknown_returns_false(cache):
+    """delete_session returns False for non-existent session."""
+    result = cache.delete_session("nonexistent-session")
+    assert result is False
+
+
+def test_delete_ephemeral_session():
+    """delete_session removes ephemeral sessions from cache."""
+    c = SessionCache()
+    c.add_ephemeral("eph-1", {"title": "Eph"}, [{"id": 0, "type": "user_message"}])
+    assert c.get_session("eph-1") is not None
+
+    result = c.delete_session("eph-1")
+    assert result is True
+    assert c.get_session("eph-1") is None


### PR DESCRIPTION
## Summary

- Skill file expansions (16KB+ user messages from `/ddd`, `/precheck`, etc.) now render as collapsed cards showing the skill name, instead of massive chat bubbles that clutter the timeline
- Adds `DELETE /api/sessions/<id>` endpoint for removing curated and ephemeral sessions (cache + manifest + disk + annotation sidecar)

## Changes

### Skill Expansion Collapse (frontend)
- `renderer.js`: Added `_stripSystemTags()`, `_renderSkillExpansion()`, detection in `renderBeat()`
- `style.css`: Added `.skill-card` styles — right-aligned, collapsible, reuses IW card toggle pattern

### DELETE Endpoint (backend)
- `api.py`: `DELETE /api/sessions/<session_id>` — handles both curated and ephemeral sessions
- `session_cache.py`: `delete_session()` — removes from `_parsed` and/or `_ephemeral`
- `annotation_store.py`: `delete()` — removes sidecar file

## Linked Issues

Closes #115

## Test Plan

- `node tests/unit/js/test_renderer.js` — 94 pass (15 new: skill cards + _stripSystemTags)
- `node tests/unit/js/test_app.js` — 234 pass
- `node tests/unit/js/test_search.js` — 24 pass
- `python3 -m pytest tests/unit/ -q` — 152 pass (9 new: DELETE curated + ephemeral + cache)
- `ruff check .` — all checks passed
- Code review: 1 critical finding (ephemeral DELETE gap) caught and fixed